### PR TITLE
Fix three critical bugs in core metadata library

### DIFF
--- a/packages/metadata/src/PluginCache.ts
+++ b/packages/metadata/src/PluginCache.ts
@@ -141,7 +141,9 @@ export class PluginCache {
    * @returns {{}}
    */
   private parseJavadocString(script: string) {
-    const dataString = script.match(/data:\s*{([\s\S]*?)};\s*/).join();
+    const matchResult = script.match(/data:\s*{([\s\S]*?)};\s*/);
+    if (!matchResult) return {};
+    const dataString = matchResult.join();
     const result = {};
     // Regular expression to match each variable block
     const varRegex = /\/\*\*\s*([\s\S]*?)\s*\*\/\s*(\w+):\s*{\s*([\s\S]*?)\s*},?/gs;

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -55,7 +55,7 @@ export default class JsPsychMetadata {
     "trial_type",
     "trial_index",
     "time_elapsed",
-    "extenstion_type",
+    "extension_type",
     "extension_version",
   ]);
   
@@ -382,30 +382,18 @@ export default class JsPsychMetadata {
     }
 
     if (ext === 'json') {
-      try {
-        parsed_data = JSON.parse(data);
-      } catch (error) {
-        console.error("Error parsing JSON data:", error);
-        return;
-      }
-    } 
-    
-    // Check if parsed_data is an array (assuming it's an array of observations)
-    if (!Array.isArray(parsed_data)) {
-      console.error("Parsed data is not in correct format: Expected an array", parsed_data);
-      return;
+      parsed_data = JSON.parse(data);
     }
 
-    if (typeof parsed_data !== "object") {
-      console.error("Unable to parse data object, not in correct format:", typeof parsed_data);
-      return;
+    if (!Array.isArray(parsed_data)) {
+      throw new Error("Parsed data is not in correct format: Expected an array of observations");
     }
 
     for (const observation of parsed_data) {
       await this.generateObservation(observation);
     }
-    
-    await this.updateMetadata(metadata); 
+
+    await this.updateMetadata(metadata);
   }
 
   /**


### PR DESCRIPTION
## Summary
- **Typo fix:** `"extenstion_type"` → `"extension_type"` in the ignored variables set — extension_type was never being filtered from variable generation
- **Crash fix:** Added null safety to `PluginCache.parseJavadocString()` — calling `.join()` on a null regex match result caused a TypeError when plugins didn't match the expected source pattern
- **Silent failure fix:** `generate()` now throws errors instead of silently returning on invalid JSON or non-array data, and removes unreachable dead code

## Test plan
- [x] `npm run build` succeeds across all packages
- [ ] Verify CI passes
- [ ] Test `generate()` with invalid JSON input (should now throw instead of silently returning)
- [ ] Test with a plugin that doesn't match the expected JSDoc pattern (should return empty object instead of crashing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)