### PR TITLE
Add CLI prompt for unknown variable descriptions

### DIFF
--- a/.changeset/unknown-descriptions-prompt.md
+++ b/.changeset/unknown-descriptions-prompt.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata-cli": minor
+---
+
+Add interactive prompt for unknown variable descriptions. After data processing and metadata options, the CLI now detects user-data variables whose descriptions could not be resolved from plugin source and asks whether to fill them in. Users can skip the entire step or skip individual variables by pressing Enter.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -161,6 +161,62 @@ const promptData = async (metadata: JsPsychMetadata, verbose: boolean, targetDir
   await processDirectory(metadata, data_path, verbose, targetDirectoryPath); // will check if already existing metadata and won't need to prompt
 }
 
+const SYSTEM_VARIABLE_NAMES = new Set([
+  "trial_type",
+  "trial_index",
+  "time_elapsed",
+  "extension_type",
+  "extension_version",
+]);
+
+function hasUnknownDescription(variable: any): boolean {
+  const desc = variable["description"];
+  if (!desc) return false;
+  if (typeof desc === "string") return desc === "unknown";
+  if (typeof desc === "object") {
+    const values = Object.values(desc) as string[];
+    return values.length > 0 && values.every((v) => v === "unknown");
+  }
+  return false;
+}
+
+const promptUnknownDescriptions = async (metadata: JsPsychMetadata) => {
+  const unknownVars = metadata.getVariableNames().filter((name) => {
+    if (SYSTEM_VARIABLE_NAMES.has(name)) return false;
+    return hasUnknownDescription(metadata.getVariable(name));
+  });
+
+  if (unknownVars.length === 0) return;
+
+  const fillIn = await select({
+    message: `${unknownVars.length} variable(s) have unknown descriptions. Would you like to fill them in?`,
+    choices: [
+      {
+        name: "Fill in descriptions",
+        value: true,
+        description: "You will be prompted for each variable. Press Enter to skip individual ones.",
+      },
+      {
+        name: "Skip",
+        value: false,
+        description: "Leave descriptions as unknown in the dataset_description.json.",
+      },
+    ],
+  });
+
+  if (!fillIn) return;
+
+  for (const name of unknownVars) {
+    const description = await input({
+      message: `Description for "${name}" (press Enter to skip):`,
+    });
+
+    if (description.trim()) {
+      metadata.updateVariable(name, "description", { user: description.trim() });
+    }
+  }
+};
+
 // can seperate the process argv's out into seperate function
 const main = async () => {
   const verbose = argv.verbose ? argv.verbose : false;
@@ -201,6 +257,14 @@ const main = async () => {
   }
   else await metadataOptionsPrompt(metadata, verbose); // passing in options file to overwite existing file
   
+  const isNonInteractive = !!(
+    argv['psych-ds-dir'] && await validateDirectory(argv['psych-ds-dir']) &&
+    argv['data-dir'] && await validateDirectory(argv['data-dir']) &&
+    argv['metadata-options'] && validateJson(argv['metadata-options'])
+  );
+
+  if (!isNonInteractive) await promptUnknownDescriptions(metadata);
+
   const metadataString = JSON.stringify(metadata.getMetadata(), null, 2); // Assuming getMetadata() is the function that retrieves your metadata
   if (argv.verbose) console.log("\n\n-------------------------- Final metadata string --------------------------\n\n", metadataString);
   saveTextToPath(metadataString,`${project_path}/dataset_description.json`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -212,6 +212,12 @@ const promptUnknownDescriptions = async (metadata: JsPsychMetadata) => {
     });
 
     if (description.trim()) {
+      // updateVariable's "description" handling is append-only — it accumulates
+      // descriptions across plugins rather than overwriting. Clear the existing
+      // "unknown" entry first so the user's value replaces it instead of sitting
+      // alongside the stale "unknown".
+      const variable = metadata.getVariable(name) as { description?: Record<string, string> };
+      variable.description = {};
       metadata.updateVariable(name, "description", { user: description.trim() });
     }
   }


### PR DESCRIPTION
## Summary

- After data processing and metadata options, the CLI now detects user-data variables whose descriptions could not be resolved from plugin source
- Shows an optional gate prompt: users can skip the entire step or fill in descriptions one by one (pressing Enter skips an individual variable)
- Suppressed automatically when all three flags (`--psych-ds-dir`, `--data-dir`, `--metadata-options`) are provided (non-interactive mode)

## Test plan

- [ ] Run CLI interactively against a data directory — confirm gate prompt appears with correct variable count
- [ ] Choose "Fill in descriptions", type a description for one variable, press Enter to skip another — verify `dataset_description.json` reflects filled-in and `"unknown"` values correctly
- [ ] Choose "Skip" at the gate — verify no per-variable prompts appear and all descriptions remain `"unknown"`
- [ ] Run with all three flags — confirm no prompt appears and CLI completes silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)