### PR TITLE
Add tests for always-empty columns fix and variableMeasured completeness

### DIFF
--- a/.changeset/csv-completeness-tests.md
+++ b/.changeset/csv-completeness-tests.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata": patch
+---
+
+Add tests verifying variableMeasured completeness for CSV input. Covers always-empty columns, null-string columns, partially-empty columns, and sparse multi-trial-type CSVs where different trial types populate different columns.

--- a/packages/metadata/tests/metadata-module.test.ts
+++ b/packages/metadata/tests/metadata-module.test.ts
@@ -66,6 +66,76 @@ describe("always-empty columns in variableMeasured", () => {
 
 });
 
+describe("variableMeasured completeness for CSV input", () => {
+  let jsPsychMetadata: JsPsychMetadata;
+
+  // Extracts every column name from a CSV header row
+  function csvColumnNames(csv: string): string[] {
+    return csv.split("\n")[0].split(",");
+  }
+
+  beforeEach(() => {
+    jsPsychMetadata = new JsPsychMetadata();
+  });
+
+  test("all columns appear when every column has values in every row", async () => {
+    const csv = [
+      "trial_type,rt,response,stimulus",
+      "jsPsych-html-keyboard-response,450,f,<p>Hello</p>",
+      "jsPsych-html-keyboard-response,512,j,<p>World</p>",
+      "jsPsych-html-keyboard-response,389,f,<p>Again</p>",
+    ].join("\n");
+
+    await jsPsychMetadata.generate(csv, {}, "csv");
+
+    const variableMeasured = jsPsychMetadata.getMetadata()["variableMeasured"] as any[];
+    const outputNames = variableMeasured.map((v) => v.name);
+
+    for (const col of csvColumnNames(csv)) {
+      expect(outputNames).toContain(col);
+    }
+  });
+
+  test("all columns appear when one column is always empty", async () => {
+    const csv = [
+      "trial_type,rt,response,eye_tracking_status",
+      "jsPsych-html-keyboard-response,450,f,",
+      "jsPsych-html-keyboard-response,512,j,",
+      "jsPsych-html-keyboard-response,389,f,",
+    ].join("\n");
+
+    await jsPsychMetadata.generate(csv, {}, "csv");
+
+    const variableMeasured = jsPsychMetadata.getMetadata()["variableMeasured"] as any[];
+    const outputNames = variableMeasured.map((v) => v.name);
+
+    for (const col of csvColumnNames(csv)) {
+      expect(outputNames).toContain(col);
+    }
+  });
+
+  test("all columns appear when different trial types populate different columns (sparse CSV)", async () => {
+    // Simulates realistic jsPsych output where keyboard-response trials have rt/response/stimulus
+    // and survey trials have question_order but leave rt and stimulus empty
+    const csv = [
+      "trial_type,rt,response,stimulus,question_order",
+      "jsPsych-html-keyboard-response,450,f,<p>Hello</p>,",
+      "jsPsych-html-keyboard-response,512,j,<p>World</p>,",
+      "jsPsych-survey-likert,,4,,forward",
+      "jsPsych-survey-likert,,2,,reverse",
+    ].join("\n");
+
+    await jsPsychMetadata.generate(csv, {}, "csv");
+
+    const variableMeasured = jsPsychMetadata.getMetadata()["variableMeasured"] as any[];
+    const outputNames = variableMeasured.map((v) => v.name);
+
+    for (const col of csvColumnNames(csv)) {
+      expect(outputNames).toContain(col);
+    }
+  });
+});
+
 // missing displaying data modules tests
 describe("JsPsychMetadata", () => {
   let jsPsychMetadata: JsPsychMetadata;

--- a/packages/metadata/tests/metadata-module.test.ts
+++ b/packages/metadata/tests/metadata-module.test.ts
@@ -66,10 +66,15 @@ describe("always-empty columns in variableMeasured", () => {
 
 });
 
+// Note: JSON input is intentionally not tested here. When reading JSON, rows with a key absent
+// entirely (rather than null/empty) never enter generateObservation for that key, so pre-registration
+// doesn't fire for that row. This is pre-existing design tied to the non-rectangular JSON structure
+// issue, which is tracked separately.
 describe("variableMeasured completeness for CSV input", () => {
   let jsPsychMetadata: JsPsychMetadata;
 
-  // Extracts every column name from a CSV header row
+  // Splits a CSV header row into column names. Assumes no quoted commas in headers — all test
+  // data here is controlled and satisfies this constraint.
   function csvColumnNames(csv: string): string[] {
     return csv.split("\n")[0].split(",");
   }
@@ -78,6 +83,7 @@ describe("variableMeasured completeness for CSV input", () => {
     jsPsychMetadata = new JsPsychMetadata();
   });
 
+  // Baseline: the fix should not break the common case where all columns have values.
   test("all columns appear when every column has values in every row", async () => {
     const csv = [
       "trial_type,rt,response,stimulus",
@@ -112,6 +118,10 @@ describe("variableMeasured completeness for CSV input", () => {
     for (const col of csvColumnNames(csv)) {
       expect(outputNames).toContain(col);
     }
+
+    // Also verify the always-empty column's description serializes correctly through getList()
+    const emptyCol = variableMeasured.find((v) => v.name === "eye_tracking_status");
+    expect(emptyCol.description).toBe("unknown");
   });
 
   test("all columns appear when different trial types populate different columns (sparse CSV)", async () => {

--- a/packages/metadata/tests/metadata-module.test.ts
+++ b/packages/metadata/tests/metadata-module.test.ts
@@ -124,25 +124,39 @@ describe("variableMeasured completeness for CSV input", () => {
     expect(emptyCol.description).toBe("unknown");
   });
 
-  test("all columns appear when different trial types populate different columns (sparse CSV)", async () => {
-    // Simulates realistic jsPsych output where keyboard-response trials have rt/response/stimulus
-    // and survey trials have question_order but leave rt and stimulus empty
+  test("sparse CSV: partially-empty columns resolve to a real type while always-empty columns stay unknown", async () => {
+    // Simulates realistic jsPsych output where keyboard-response trials populate rt/stimulus and
+    // survey trials populate question_order, each leaving the other columns empty. eye_tracking_status
+    // is empty in every row. This exercises the pre-registration upgrade path: a column first seen with
+    // an empty value is registered as value:"unknown", then upgraded to its real type once any later
+    // row supplies a concrete value — but only for columns that are ever populated.
     const csv = [
-      "trial_type,rt,response,stimulus,question_order",
-      "jsPsych-html-keyboard-response,450,f,<p>Hello</p>,",
-      "jsPsych-html-keyboard-response,512,j,<p>World</p>,",
-      "jsPsych-survey-likert,,4,,forward",
-      "jsPsych-survey-likert,,2,,reverse",
+      "trial_type,rt,response,stimulus,question_order,eye_tracking_status",
+      "jsPsych-html-keyboard-response,450,f,<p>Hello</p>,,", // rt/stimulus set; question_order empty here
+      "jsPsych-html-keyboard-response,512,j,<p>World</p>,,",
+      "jsPsych-survey-likert,,4,,forward,", // rt/stimulus empty here; question_order set
+      "jsPsych-survey-likert,,2,,reverse,",
     ].join("\n");
 
     await jsPsychMetadata.generate(csv, {}, "csv");
 
     const variableMeasured = jsPsychMetadata.getMetadata()["variableMeasured"] as any[];
     const outputNames = variableMeasured.map((v) => v.name);
+    const byName = (name: string) => variableMeasured.find((v) => v.name === name);
 
+    // Every header is still present regardless of sparsity.
     for (const col of csvColumnNames(csv)) {
       expect(outputNames).toContain(col);
     }
+
+    // Columns empty in the *first* row they appear in must still upgrade to their real type once a
+    // later row populates them — the "unknown" placeholder must not stick.
+    expect(byName("question_order").value).toBe("string"); // populated only in the survey rows
+    expect(byName("rt").value).toBe("number"); // populated only in the keyboard rows
+
+    // A column with no value in any row keeps the placeholder.
+    expect(byName("eye_tracking_status").value).toBe("unknown");
+    expect(byName("eye_tracking_status").description).toBe("unknown");
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds 3 targeted tests for the always-empty columns fix (PR #46): all-empty column, null-string column, and partially-empty column that should resolve to a real type
- Adds 3 completeness tests asserting that every CSV header appears in `variableMeasured` after `generate()`: baseline (all columns populated), one always-empty column, and a sparse/multi-trial-type CSV

> **Depends on PR #46** — this branch is built on top of `fix/always-empty-columns-variableMeasured`. Plan is to merge #46 first, rebase this branch onto main, verify tests pass, then merge.

## Test plan

- [ ] Merge PR #46 and rebase this branch onto main
- [ ] Run `npm test` in `packages/metadata` — all tests should pass
- [ ] Confirm the sparse CSV test covers realistic jsPsych output (mixed trial types populating different columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)