### PR TITLE
Add Jest test infrastructure and tests for CLI package

### DIFF
--- a/.changeset/cli-tests.md
+++ b/.changeset/cli-tests.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata-cli": patch
+---
+
+Add Jest test infrastructure and tests for the CLI package. Tests cover `utils.ts`, `validatefunctions.ts`, and `data.ts` (27 tests). Also modernizes `saveTextToPath` from a fire-and-forget callback to an `async` function returning `Promise<void>`.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,3 +1,3 @@
 module.exports = {
-  projects: ["packages/metadata"],
+  projects: ["packages/metadata", "packages/cli"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14075,6 +14075,11 @@
       },
       "bin": {
         "jspsych-metadata-cli": "dist/cjs/index.cjs"
+      },
+      "devDependencies": {
+        "@sucrase/jest-plugin": "^3.0.0",
+        "@types/jest": "^29.5.12",
+        "jest": "^29.7.0"
       }
     },
     "packages/frontend": {
@@ -14463,17 +14468,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "packages/frontend/node_modules/@types/node": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
-      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.13.0"
       }
     },
     "packages/frontend/node_modules/@vitejs/plugin-react-swc": {

--- a/packages/cli/jest.config.cjs
+++ b/packages/cli/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  transform: { "\\.(js|jsx|ts|tsx)$": "@sucrase/jest-plugin" },
+  testEnvironment: "node",
+  displayName: { name: "cli", color: "cyanBright" },
+};

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,9 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.12"
+    "@sucrase/jest-plugin": "^3.0.0",
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0"
   },
   "dependencies": {
     "@inquirer/prompts": "^5.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,11 @@
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "esbuild src/index.ts --bundle --format=esm --platform=node --outfile=dist/esm/index.js",
     "build:cjs": "esbuild src/index.ts --bundle --format=cjs --platform=node --outfile=dist/cjs/index.cjs",
-    "cli": "node dist/esm/index.js"
+    "cli": "node dist/esm/index.js",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12"
   },
   "dependencies": {
     "@inquirer/prompts": "^5.1.2",

--- a/packages/cli/src/data.ts
+++ b/packages/cli/src/data.ts
@@ -128,16 +128,15 @@ export const processOptions = async (metadata: JsPsychMetadata, filePath: string
   }
 }
 
-export function saveTextToPath(textstr: string, filePath: string = './file.txt') {
+export async function saveTextToPath(textstr: string, filePath: string = './file.txt'): Promise<void> {
   filePath = expandHomeDir(filePath);
 
-  fs.writeFile(filePath, textstr, 'utf8', (err) => {
-    if (err) {
-      console.error(`\nError writing to file ${filePath}:`, err);
-    } else {
-      console.log(`\n✔ File ${filePath} has been saved.`);
-    }
-  });
+  try {
+    await fs.promises.writeFile(filePath, textstr, 'utf8');
+    console.log(`\n✔ File ${filePath} has been saved.`);
+  } catch (err) {
+    console.error(`\nError writing to file ${filePath}:`, err);
+  }
 }
 
 // function for loading metadata

--- a/packages/cli/tests/data.test.ts
+++ b/packages/cli/tests/data.test.ts
@@ -1,0 +1,156 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import JsPsychMetadata from "@jspsych/metadata";
+import { processOptions, loadMetadata, saveTextToPath, processDirectory } from "../src/data";
+
+// Each describe block gets its own temp directory.
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cli-data-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("saveTextToPath", () => {
+  test("writes content to a new file", (done) => {
+    const filePath = path.join(tmpDir, "output.json");
+    saveTextToPath('{"name":"test"}', filePath);
+    // saveTextToPath uses async fs.writeFile; poll briefly for completion
+    setTimeout(() => {
+      expect(fs.existsSync(filePath)).toBe(true);
+      expect(fs.readFileSync(filePath, "utf8")).toBe('{"name":"test"}');
+      done();
+    }, 100);
+  });
+
+  test("overwrites an existing file", (done) => {
+    const filePath = path.join(tmpDir, "output.json");
+    fs.writeFileSync(filePath, "old content");
+    saveTextToPath("new content", filePath);
+    setTimeout(() => {
+      expect(fs.readFileSync(filePath, "utf8")).toBe("new content");
+      done();
+    }, 100);
+  });
+});
+
+describe("processOptions", () => {
+  test("applies metadata options from a valid JSON file", async () => {
+    const options = { name: "My Experiment", description: "A test study" };
+    const optionsPath = path.join(tmpDir, "options.json");
+    fs.writeFileSync(optionsPath, JSON.stringify(options));
+
+    const metadata = new JsPsychMetadata();
+    const result = await processOptions(metadata, optionsPath);
+
+    expect(result).toBe(true);
+    expect(metadata.getMetadataField("name")).toBe("My Experiment");
+    expect(metadata.getMetadataField("description")).toBe("A test study");
+  });
+
+  test("returns false for a non-existent options file", async () => {
+    const metadata = new JsPsychMetadata();
+    const result = await processOptions(metadata, path.join(tmpDir, "missing.json"));
+    expect(result).toBe(false);
+  });
+
+  test("returns false for a file with invalid JSON", async () => {
+    const badPath = path.join(tmpDir, "bad.json");
+    fs.writeFileSync(badPath, "not valid json {{");
+    const metadata = new JsPsychMetadata();
+    const result = await processOptions(metadata, badPath);
+    expect(result).toBe(false);
+  });
+});
+
+describe("loadMetadata", () => {
+  test("loads metadata from a valid dataset_description.json", async () => {
+    const existing = { name: "Loaded Study", description: "Pre-existing metadata" };
+    const filePath = path.join(tmpDir, "dataset_description.json");
+    fs.writeFileSync(filePath, JSON.stringify(existing));
+
+    const metadata = new JsPsychMetadata();
+    const result = await loadMetadata(metadata, filePath);
+
+    expect(result).toBe(true);
+    expect(metadata.getMetadataField("name")).toBe("Loaded Study");
+  });
+
+  test("returns false when the file is not named dataset_description.json", async () => {
+    const filePath = path.join(tmpDir, "other.json");
+    fs.writeFileSync(filePath, JSON.stringify({ name: "test" }));
+
+    const metadata = new JsPsychMetadata();
+    const result = await loadMetadata(metadata, filePath);
+    expect(result).toBe(false);
+  });
+
+  test("returns false for a non-existent file", async () => {
+    const metadata = new JsPsychMetadata();
+    const result = await loadMetadata(metadata, path.join(tmpDir, "dataset_description.json"));
+    expect(result).toBe(false);
+  });
+});
+
+describe("processDirectory", () => {
+  test("processes a directory of CSV files and returns correct counts", async () => {
+    fs.writeFileSync(path.join(tmpDir, "trial1.csv"), "trial_type,rt\njsPsych-html-keyboard-response,450");
+    fs.writeFileSync(path.join(tmpDir, "trial2.csv"), "trial_type,rt\njsPsych-html-keyboard-response,512");
+
+    const metadata = new JsPsychMetadata();
+    const { total, failed } = await processDirectory(metadata, tmpDir);
+
+    expect(total).toBe(2);
+    expect(failed).toBe(0);
+  });
+
+  test("processes a directory of JSON files", async () => {
+    const data = JSON.stringify([{ trial_type: "jsPsych-html-keyboard-response", rt: 450 }]);
+    fs.writeFileSync(path.join(tmpDir, "data.json"), data);
+
+    const metadata = new JsPsychMetadata();
+    const { total, failed } = await processDirectory(metadata, tmpDir);
+
+    expect(total).toBe(1);
+    expect(failed).toBe(0);
+  });
+
+  test("counts unsupported file types as failed", async () => {
+    fs.writeFileSync(path.join(tmpDir, "notes.txt"), "just a text file");
+
+    const metadata = new JsPsychMetadata();
+    const { total, failed } = await processDirectory(metadata, tmpDir);
+
+    expect(total).toBe(1);
+    expect(failed).toBe(1);
+  });
+
+  test("processes subdirectories one level deep", async () => {
+    const subDir = path.join(tmpDir, "sub");
+    fs.mkdirSync(subDir);
+    fs.writeFileSync(path.join(subDir, "trial.csv"), "trial_type,rt\njsPsych-html-keyboard-response,300");
+
+    const metadata = new JsPsychMetadata();
+    const { total, failed } = await processDirectory(metadata, tmpDir);
+
+    expect(total).toBe(1);
+    expect(failed).toBe(0);
+  });
+
+  test("skips dataset_description.json (loads it as existing metadata instead)", async () => {
+    const existing = JSON.stringify({ name: "Existing", "@type": "Dataset", description: { default: "test" }, variableMeasured: [] });
+    fs.writeFileSync(path.join(tmpDir, "dataset_description.json"), existing);
+    fs.writeFileSync(path.join(tmpDir, "trial.csv"), "trial_type,rt\njsPsych-html-keyboard-response,450");
+
+    const metadata = new JsPsychMetadata();
+    const { total, failed } = await processDirectory(metadata, tmpDir);
+
+    // dataset_description.json is counted but loaded as metadata, not as a data failure
+    expect(failed).toBe(0);
+    expect(metadata.getMetadataField("name")).toBe("Existing");
+  });
+});

--- a/packages/cli/tests/data.test.ts
+++ b/packages/cli/tests/data.test.ts
@@ -16,25 +16,18 @@ afterEach(() => {
 });
 
 describe("saveTextToPath", () => {
-  test("writes content to a new file", (done) => {
+  test("writes content to a new file", async () => {
     const filePath = path.join(tmpDir, "output.json");
-    saveTextToPath('{"name":"test"}', filePath);
-    // saveTextToPath uses async fs.writeFile; poll briefly for completion
-    setTimeout(() => {
-      expect(fs.existsSync(filePath)).toBe(true);
-      expect(fs.readFileSync(filePath, "utf8")).toBe('{"name":"test"}');
-      done();
-    }, 100);
+    await saveTextToPath('{"name":"test"}', filePath);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(fs.readFileSync(filePath, "utf8")).toBe('{"name":"test"}');
   });
 
-  test("overwrites an existing file", (done) => {
+  test("overwrites an existing file", async () => {
     const filePath = path.join(tmpDir, "output.json");
     fs.writeFileSync(filePath, "old content");
-    saveTextToPath("new content", filePath);
-    setTimeout(() => {
-      expect(fs.readFileSync(filePath, "utf8")).toBe("new content");
-      done();
-    }, 100);
+    await saveTextToPath("new content", filePath);
+    expect(fs.readFileSync(filePath, "utf8")).toBe("new content");
   });
 });
 

--- a/packages/cli/tests/utils.test.ts
+++ b/packages/cli/tests/utils.test.ts
@@ -1,0 +1,35 @@
+import os from "os";
+import path from "path";
+import { expandHomeDir } from "../src/utils";
+import { generatePath } from "../src/data";
+
+describe("expandHomeDir", () => {
+  test("expands leading ~ to the home directory", () => {
+    const result = expandHomeDir("~/documents/data");
+    expect(result).toBe(path.join(os.homedir(), "/documents/data"));
+  });
+
+  test("returns path unchanged when it does not start with ~", () => {
+    const absolute = "/usr/local/data";
+    expect(expandHomeDir(absolute)).toBe(absolute);
+
+    const relative = "some/relative/path";
+    expect(expandHomeDir(relative)).toBe(relative);
+  });
+
+  test("handles bare ~ as the home directory", () => {
+    expect(expandHomeDir("~")).toBe(path.join(os.homedir(), ""));
+  });
+});
+
+describe("generatePath", () => {
+  test("returns an absolute path unchanged", () => {
+    const absolute = path.resolve("/some/absolute/path");
+    expect(generatePath(absolute)).toBe(absolute);
+  });
+
+  test("resolves a relative path against the current working directory", () => {
+    const relative = "relative/path";
+    expect(generatePath(relative)).toBe(path.resolve(process.cwd(), relative));
+  });
+});

--- a/packages/cli/tests/validatefunctions.test.ts
+++ b/packages/cli/tests/validatefunctions.test.ts
@@ -1,0 +1,73 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { validateDirectory, validateJson } from "../src/validatefunctions";
+
+// Each test suite gets its own temp directory, cleaned up after all tests in the suite.
+describe("validateDirectory", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cli-test-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns true for an existing directory", async () => {
+    expect(await validateDirectory(tmpDir)).toBe(true);
+  });
+
+  test("returns false for a path that is a file, not a directory", async () => {
+    const filePath = path.join(tmpDir, "notadir.txt");
+    fs.writeFileSync(filePath, "hello");
+    expect(await validateDirectory(filePath)).toBe(false);
+  });
+
+  test("returns false for a non-existent path", async () => {
+    expect(await validateDirectory(path.join(tmpDir, "does-not-exist"))).toBe(false);
+  });
+
+  test("expands ~ before validating", async () => {
+    // os.homedir() is a real directory, so this should return true
+    expect(await validateDirectory("~")).toBe(true);
+  });
+});
+
+describe("validateJson", () => {
+  let tmpDir: string;
+  let validJsonPath: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cli-test-"));
+    validJsonPath = path.join(tmpDir, "dataset_description.json");
+    fs.writeFileSync(validJsonPath, JSON.stringify({ name: "test" }));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns true for a valid .json file", () => {
+    expect(validateJson(validJsonPath)).toBe(true);
+  });
+
+  test("returns true when fileName matches", () => {
+    expect(validateJson(validJsonPath, "dataset_description.json")).toBe(true);
+  });
+
+  test("returns false when fileName does not match", () => {
+    expect(validateJson(validJsonPath, "other.json")).toBe(false);
+  });
+
+  test("returns false for a non-existent file", () => {
+    expect(validateJson(path.join(tmpDir, "missing.json"))).toBe(false);
+  });
+
+  test("returns false for a file without a .json extension", () => {
+    const csvPath = path.join(tmpDir, "data.csv");
+    fs.writeFileSync(csvPath, "a,b,c");
+    expect(validateJson(csvPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Jest + `@sucrase/jest-plugin` test infrastructure to `packages/cli`
- Tests for `utils.ts`, `validatefunctions.ts`, and `data.ts` (27 tests total, all passing)
- Modernizes `saveTextToPath` from callback-based `fs.writeFile` to `async`/`await` with `fs.promises.writeFile`

## Notes

`index.ts` and `handlefiles.ts` are intentionally out of scope — testing the interactive `@inquirer/prompts` entrypoint would require a separate mocking effort.

## Test plan

- [ ] `cd packages/cli && npx jest` — all 27 tests pass
- [ ] Verify no regressions in `packages/metadata` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)