### PR TITLE
Convert jsPsych JSON data files to CSV for Psych-DS validation

### DIFF
--- a/.changeset/json-to-csv-conversion.md
+++ b/.changeset/json-to-csv-conversion.md
@@ -2,4 +2,8 @@
 "@jspsych/metadata-cli": minor
 ---
 
-Convert jsPsych JSON data files to CSV so generated projects pass the Psych-DS validator. When processing a directory, each `.json` data file is now written as a `.csv` in `data/` (nested objects/arrays serialized as JSON strings via `objectsToCSV`, so no data is lost), with the untouched original preserved under `data/raw/`. The project scaffold creates the `data/raw/` directory, `.csv` inputs are copied through unchanged, and `dataset_description.json` is left untouched. Same-named source files are skipped rather than silently overwritten.
+Convert jsPsych JSON data files to CSV and normalize all generated data filenames to the Psych-DS `[keyword-value_]+data.csv` pattern, so generated projects pass the Psych-DS validator.
+
+- Each `.json` data file is converted to a `.csv` in `data/` (nested objects/arrays serialized as JSON strings via `objectsToCSV`, so no data is lost), with the untouched original preserved under `data/raw/`. The project scaffold creates the `data/raw/` directory, and `dataset_description.json` is left untouched.
+- Output filenames follow the Psych-DS naming pattern. Already-compliant names are kept; for non-compliant ones the CLI prompts once for a keyword (official keywords offered to avoid validator warnings; custom keywords allowed), with the file's current name becoming the value (camelCased, since Psych-DS values forbid hyphens/underscores). The same normalized base names the converted/copied CSV and its extracted-array CSVs, fixing previously invalid extracted-array names.
+- Same-named source files from different subdirectories are kept and disambiguated with a validator-safe counter — both the CSV in `data/` and the original in `data/raw/` — instead of being skipped or silently overwritten. Non-interactive runs fail with a clear message rather than inventing a keyword.

--- a/.changeset/json-to-csv-conversion.md
+++ b/.changeset/json-to-csv-conversion.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata-cli": minor
+---
+
+Convert jsPsych JSON data files to CSV so generated projects pass the Psych-DS validator. When processing a directory, each `.json` data file is now written as a `.csv` in `data/` (nested objects/arrays serialized as JSON strings via `objectsToCSV`, so no data is lost), with the untouched original preserved under `data/raw/`. The project scaffold creates the `data/raw/` directory, `.csv` inputs are copied through unchanged, and `dataset_description.json` is left untouched. Same-named source files are skipped rather than silently overwritten.

--- a/packages/cli/src/data.ts
+++ b/packages/cli/src/data.ts
@@ -1,11 +1,19 @@
 import fs from "fs";
 import path from "path";
 import JsPsychMetadata, { analyzeJoinKeys, JoinKeyAnalysis, parseCSV } from "@jspsych/metadata";
-import { expandHomeDir, deriveArrayFilename, disambiguateArrayFilename, objectsToCSV } from "./utils";
+import { expandHomeDir, deriveArrayFilename, disambiguateArrayFilename, disambiguateFilename, objectsToCSV, fileStem, isValidPsychDSDataFilename } from "./utils";
 
 export interface GenerateOptions {
   arrayJoinKeys?: string[];
   suppressJoinKeyWarning?: boolean;
+  /**
+   * Maps an absolute source-file path to its resolved Psych-DS base (the keyword-value
+   * sequence before "_data.csv"). Built by the index.ts pre-pass, which prompts for a
+   * keyword when a filename is non-compliant. A file missing from the map falls back to
+   * its own stem, which is only accepted if it is already Psych-DS-compliant; otherwise
+   * the file is skipped (processFile never invents a keyword — that is the pre-pass's job).
+   */
+  normalizedBases?: Map<string, string>;
 }
 
 /**
@@ -77,6 +85,38 @@ export async function preAnalyzeDirectory(
   return worst;
 }
 
+/**
+ * Lists candidate data files at the top level and one subdirectory deep, matching
+ * processDirectory's traversal depth. Returns absolute-ready { filePath, name } pairs
+ * (directories themselves are excluded). Used by the filename-normalization pre-pass.
+ */
+export async function enumerateDataFiles(directoryPath: string): Promise<Array<{ filePath: string; name: string }>> {
+  directoryPath = expandHomeDir(directoryPath);
+  const out: Array<{ filePath: string; name: string }> = [];
+
+  let items: fs.Dirent[];
+  try {
+    items = await fs.promises.readdir(directoryPath, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+
+  for (const item of items) {
+    if (item.isDirectory()) {
+      try {
+        const subItems = await fs.promises.readdir(path.join(directoryPath, item.name), { withFileTypes: true });
+        for (const subItem of subItems) {
+          if (!subItem.isDirectory()) out.push({ filePath: path.join(directoryPath, item.name, subItem.name), name: subItem.name });
+        }
+      } catch { continue; }
+    } else {
+      out.push({ filePath: path.join(directoryPath, item.name), name: item.name });
+    }
+  }
+
+  return out;
+}
+
 // creating path -> handles the absolute vs non-absolute paths
 export const generatePath = (inputPath: string): string => {
   if (path.isAbsolute(inputPath)) {
@@ -107,7 +147,7 @@ const copyFileWithStructure = async (sourceFilePath: string, verbose: boolean, t
 };
 
 // processing single file, need to refactor this into a seperate call
-const processFile = async (metadata: JsPsychMetadata, directoryPath: string, file: string, verbose: boolean, targetDirectoryPath?: string, options: GenerateOptions = {}, usedArrayFilenames: Set<string> = new Set()) => {
+const processFile = async (metadata: JsPsychMetadata, directoryPath: string, file: string, verbose: boolean, targetDirectoryPath?: string, options: GenerateOptions = {}, usedArrayFilenames: Set<string> = new Set(), usedRawFilenames: Set<string> = new Set()) => {
   const filePath = path.join(directoryPath, file);
   if (verbose) console.log("Reading file:", filePath);
 
@@ -137,30 +177,51 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
         return true;
       }
 
+      // For JSON sources, parse and validate first so a non-array (or unparseable) file is
+      // skipped before it reserves an output name — otherwise it would needlessly disambiguate
+      // a later valid file that maps to the same base.
+      let parsed: Array<Record<string, any>> | null = null;
       if (fileExtension === '.json') {
-        // Validator-ready output: keep the original JSON under data/raw/, write a converted CSV to data/.
-        const parsed = JSON.parse(content);
-        if (!Array.isArray(parsed)) {
+        const json = JSON.parse(content);
+        if (!Array.isArray(json)) {
           console.error(`"${file}" is not a JSON array of jsPsych trials; skipping CSV conversion.`);
           return false;
         }
+        parsed = json;
+      }
 
-        const csvName = `${path.basename(file, '.json')}.csv`;
-        if (usedArrayFilenames.has(csvName)) {
-          console.error(`Naming collision: "${file}" would overwrite "${csvName}" in data/. Rename one of the source files (Psych-DS naming is handled separately). Skipping.`);
-          return false;
-        }
-        usedArrayFilenames.add(csvName);
+      // Resolve the Psych-DS base (keyword-value sequence before "_data.csv"). The index.ts
+      // pre-pass supplies a base for every source file; fall back to the file's own stem when
+      // called directly (e.g. in tests). Never invent a keyword here — if the resolved base
+      // would not yield a Psych-DS-compliant filename, skip the file rather than writing an
+      // invalid name. The CLI's pre-pass is the single place that prompts to fix such names.
+      const base = options.normalizedBases?.get(path.resolve(filePath)) ?? fileStem(file);
+      if (!isValidPsychDSDataFilename(`${base}_data.csv`)) {
+        console.error(`"${file}" does not follow the Psych-DS naming pattern ([keyword-value_]+data.csv) and no compliant name was provided; skipping. Run via the CLI (which prompts for a keyword) or supply options.normalizedBases.`);
+        return false;
+      }
+      const mainName = disambiguateArrayFilename(`${base}_data.csv`, usedArrayFilenames);
+      usedArrayFilenames.add(mainName);
 
+      if (parsed) {
+        // Keep the original JSON under data/raw/, write a converted, Psych-DS-named CSV to data/.
+        // data/raw/ is flat (one level deep is flattened), so same-named originals from different
+        // source subdirectories must be disambiguated or they would overwrite one another.
         const rawDir = path.join(targetDirectoryPath, 'raw');
         await fs.promises.mkdir(rawDir, { recursive: true });
-        await fs.promises.writeFile(path.join(rawDir, file), content);
+        const rawName = disambiguateFilename(file, usedRawFilenames);
+        usedRawFilenames.add(rawName);
+        if (rawName !== file) {
+          console.log(`  ! raw/"${file}" already exists; saving original as raw/"${rawName}" instead.`);
+        }
+        await fs.promises.writeFile(path.join(rawDir, rawName), content);
 
-        await fs.promises.writeFile(path.join(targetDirectoryPath, csvName), objectsToCSV(parsed, ['trial_index']));
-        if (verbose) console.log(`  → converted ${file} to ${csvName} (raw saved to raw/${file})`);
+        await fs.promises.writeFile(path.join(targetDirectoryPath, mainName), objectsToCSV(parsed, ['trial_index']));
+        if (verbose) console.log(`  → converted ${file} to ${mainName} (raw saved to raw/${rawName})`);
       } else {
-        // .csv input is already validator-ready; copy it through unchanged.
-        await copyFileWithStructure(filePath, verbose, targetDirectoryPath);
+        // .csv input is already CSV; write it out under its Psych-DS-compliant name.
+        await fs.promises.writeFile(path.join(targetDirectoryPath, mainName), content);
+        if (verbose) console.log(`  → wrote ${file} as ${mainName}`);
       }
 
       // Write a separate Psych-DS CSV for each array-of-objects column detected during generate()
@@ -168,7 +229,7 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
       const joinKeys = metadata.getArrayJoinKeys();
       const priorityCols = [...joinKeys, 'element_index'];
       for (const [colName, rows] of extractedArrays) {
-        const derivedFilename = deriveArrayFilename(file, colName);
+        const derivedFilename = deriveArrayFilename(base, colName);
         const outFilename = disambiguateArrayFilename(derivedFilename, usedArrayFilenames);
         if (outFilename !== derivedFilename) {
           console.log(`  ! "${derivedFilename}" already exists; writing array data for "${colName}" as "${outFilename}" instead.`);
@@ -192,9 +253,11 @@ export const processDirectory = async (metadata: JsPsychMetadata, directoryPath:
   directoryPath = expandHomeDir(directoryPath);
   let total = 0;
   let failed = 0;
-  // Shared across all files so extracted-array CSV names are disambiguated against the
-  // whole output directory, not just within a single source file.
+  // Shared across all files so output names are disambiguated against the whole output
+  // directory, not just within a single source file: usedArrayFilenames tracks data/ CSVs,
+  // usedRawFilenames tracks preserved originals under data/raw/.
   const usedArrayFilenames = new Set<string>();
+  const usedRawFilenames = new Set<string>();
 
   const processDirectoryRecursive = async (currentPath: string, level: number) => {
     if (level > 1){ 
@@ -218,7 +281,7 @@ export const processDirectory = async (metadata: JsPsychMetadata, directoryPath:
           await processDirectoryRecursive(itemPath, level + 1);
         } else {
           total += 1;
-          if (!await processFile(metadata, currentPath, item.name, verbose, targetDirectoryPath, options, usedArrayFilenames)) failed += 1; // returns false if failed
+          if (!await processFile(metadata, currentPath, item.name, verbose, targetDirectoryPath, options, usedArrayFilenames, usedRawFilenames)) failed += 1; // returns false if failed
         }
       }
 

--- a/packages/cli/src/data.ts
+++ b/packages/cli/src/data.ts
@@ -129,12 +129,39 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
     }
 
     if (targetDirectoryPath) {
-      await copyFileWithStructure(filePath, verbose, targetDirectoryPath);
+      // dataset_description.json takes the loadMetadata() branch above. Copy it through
+      // unchanged and skip conversion + array extraction (the latter would re-write the
+      // previous data file's array rows under a filename derived from this one).
+      if (file === "dataset_description.json") {
+        await copyFileWithStructure(filePath, verbose, targetDirectoryPath);
+        return true;
+      }
 
-      // dataset_description.json takes the loadMetadata() branch above, which does not
-      // reset extractedArrays. Without this guard we would re-write the previous data
-      // file's array rows under a filename derived from "dataset_description.json".
-      if (file === "dataset_description.json") return true;
+      if (fileExtension === '.json') {
+        // Validator-ready output: keep the original JSON under data/raw/, write a converted CSV to data/.
+        const parsed = JSON.parse(content);
+        if (!Array.isArray(parsed)) {
+          console.error(`"${file}" is not a JSON array of jsPsych trials; skipping CSV conversion.`);
+          return false;
+        }
+
+        const csvName = `${path.basename(file, '.json')}.csv`;
+        if (usedArrayFilenames.has(csvName)) {
+          console.error(`Naming collision: "${file}" would overwrite "${csvName}" in data/. Rename one of the source files (Psych-DS naming is handled separately). Skipping.`);
+          return false;
+        }
+        usedArrayFilenames.add(csvName);
+
+        const rawDir = path.join(targetDirectoryPath, 'raw');
+        await fs.promises.mkdir(rawDir, { recursive: true });
+        await fs.promises.writeFile(path.join(rawDir, file), content);
+
+        await fs.promises.writeFile(path.join(targetDirectoryPath, csvName), objectsToCSV(parsed, ['trial_index']));
+        if (verbose) console.log(`  → converted ${file} to ${csvName} (raw saved to raw/${file})`);
+      } else {
+        // .csv input is already validator-ready; copy it through unchanged.
+        await copyFileWithStructure(filePath, verbose, targetDirectoryPath);
+      }
 
       // Write a separate Psych-DS CSV for each array-of-objects column detected during generate()
       const extractedArrays = metadata.getExtractedArrays();

--- a/packages/cli/src/handlefiles.ts
+++ b/packages/cli/src/handlefiles.ts
@@ -2,36 +2,36 @@ import fs from 'fs';
 import path from 'path';
 import { expandHomeDir } from './utils';
 
+// A nestable description of files (string content) and directories (nested objects).
+interface DirStructure {
+  [name: string]: string | DirStructure;
+}
 
 // creates directory structure for the Psych-Ds format allowing future functions to write data to here
 export function createDirectoryWithStructure(directoryPath: string): void {
   const expandedPath = expandHomeDir(directoryPath); // accounting for ~ home directory
 
-  const structure = {
+  const structure: DirStructure = {
     'data': {
+      'raw': {},
     },
     'README.md':
       `# My Project\nHuman-readable description of the project and dataset.`,
     'CHANGES.md': 'For version tracking - if the dataset is updated after being uploaded/shared, changes (with human-readable descriptions) may be recorded here.',
   };
 
-  // Create the directory
-  fs.mkdirSync(expandedPath, { recursive: true });
+  const writeStructure = (basePath: string, struct: DirStructure): void => {
+    fs.mkdirSync(basePath, { recursive: true });
 
-  // Iterate over the structure object
-  for (const [fileName, content] of Object.entries(structure)) {
-    const filePath = path.join(expandedPath, fileName);
-
-    if (typeof content === 'string') {
-      // Write the file with the provided content
-      fs.writeFileSync(filePath, content);
-    } else {
-      // Create subdirectories and files
-      fs.mkdirSync(filePath);
-      for (const [subFileName, subContent] of Object.entries(content)) {
-        const subFilePath = path.join(filePath, subFileName);
-        fs.writeFileSync(subFilePath, subContent);
+    for (const [name, content] of Object.entries(struct)) {
+      const targetPath = path.join(basePath, name);
+      if (typeof content === 'string') {
+        fs.writeFileSync(targetPath, content);
+      } else {
+        writeStructure(targetPath, content); // nested object → directory
       }
     }
-  }
+  };
+
+  writeStructure(expandedPath, structure);
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,9 +4,11 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { input, select, checkbox, Separator } from '@inquirer/prompts';
 import JsPsychMetadata, { analyzeJoinKeys, JoinKeyAnalysis } from "@jspsych/metadata";
-import { processDirectory, processOptions, saveTextToPath, loadMetadata, preAnalyzeDirectory } from "./data";
+import path from 'path';
+import { processDirectory, processOptions, saveTextToPath, loadMetadata, preAnalyzeDirectory, enumerateDataFiles } from "./data";
 import { validateDirectory, validateJson, validatePsychDS } from './validatefunctions';
 import { createDirectoryWithStructure } from './handlefiles';
+import { isValidPsychDSDataFilename, toPsychDSValue, fileStem } from './utils';
 
 // Define a type for the parsed arguments
 interface Argv {
@@ -299,6 +301,92 @@ const promptUnknownDescriptions = async (metadata: JsPsychMetadata) => {
   }
 };
 
+// Official Psych-DS keywords (psychds-validator schema). Using one of these as the keyword
+// for a non-compliant filename avoids the FILENAME_UNOFFICIAL_KEYWORD_WARNING; custom
+// keywords are allowed but emit that warning.
+const PSYCH_DS_KEYWORDS: Array<{ name: string; value: string; description: string }> = [
+  { name: 'subject', value: 'subject', description: 'The participant/subject the data belongs to' },
+  { name: 'session', value: 'session', description: 'A session of data collection' },
+  { name: 'task', value: 'task', description: 'The task in which the data was collected' },
+  { name: 'condition', value: 'condition', description: 'The experimental condition' },
+  { name: 'trial', value: 'trial', description: 'The trial the data belongs to' },
+  { name: 'stimulus', value: 'stimulus', description: 'The stimulus item' },
+  { name: 'study', value: 'study', description: 'The study the data belongs to' },
+  { name: 'site', value: 'site', description: 'The site where the data was collected' },
+  { name: 'description', value: 'description', description: 'A free-form label describing the file' },
+];
+
+/**
+ * Pre-pass: resolves a Psych-DS-compliant base (the keyword-value sequence before "_data.csv")
+ * for every data file in `dataDir`. Already-compliant filenames keep their base; non-compliant
+ * ones are wrapped under a single keyword chosen via one shared prompt, with the file's current
+ * stem becoming the value. Returns a map of absolute source path → base.
+ *
+ * When `canPrompt` is false (non-interactive run), a non-compliant filename is a hard error —
+ * we never silently invent a keyword.
+ */
+async function resolveFilenameNormalization(dataDir: string, canPrompt: boolean): Promise<Map<string, string>> {
+  const files = await enumerateDataFiles(dataDir);
+  const bases = new Map<string, string>();
+  const nonCompliant: Array<{ filePath: string; name: string }> = [];
+
+  for (const { filePath, name } of files) {
+    if (name === 'dataset_description.json') continue;
+    const ext = path.extname(name).toLowerCase();
+    if (ext !== '.json' && ext !== '.csv') continue;
+
+    const stem = fileStem(name);
+    if (isValidPsychDSDataFilename(`${stem}_data.csv`)) {
+      bases.set(path.resolve(filePath), stem);
+    } else {
+      nonCompliant.push({ filePath, name });
+    }
+  }
+
+  if (nonCompliant.length === 0) return bases;
+
+  const fileList = nonCompliant.map((f) => `    ${f.name}`).join('\n');
+
+  if (!canPrompt) {
+    console.error(
+      `\n✘ ${nonCompliant.length} data file(s) do not follow the Psych-DS naming pattern ` +
+      `([keyword-value_]+data.csv), and this is a non-interactive run:\n${fileList}\n` +
+      `  Rename them to a compliant name (e.g. subject-001_data.csv) and re-run.`
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `\n${nonCompliant.length} data file(s) do not follow the Psych-DS naming pattern ` +
+    `([keyword-value_]+data.csv):\n${fileList}`
+  );
+
+  const CUSTOM = '__custom__';
+  let keyword = await select({
+    message: 'Choose a Psych-DS keyword to label these files (their current name becomes the value):',
+    choices: [
+      ...PSYCH_DS_KEYWORDS,
+      new Separator(),
+      { name: 'Other (custom keyword)', value: CUSTOM, description: 'Unofficial keywords are allowed but emit a validator warning.' },
+    ],
+  });
+
+  if (keyword === CUSTOM) {
+    keyword = await input({
+      message: 'Custom keyword (lowercase letters only):',
+      validate: (v) => /^[a-z]+$/.test(v) ? true : 'Keyword must be one or more lowercase letters (a–z) — no digits, spaces, or symbols.',
+    });
+  }
+
+  for (const { filePath, name } of nonCompliant) {
+    const base = `${keyword}-${toPsychDSValue(fileStem(name))}`;
+    bases.set(path.resolve(filePath), base);
+    console.log(`    ${name} → ${base}_data.csv`);
+  }
+
+  return bases;
+}
+
 // can seperate the process argv's out into seperate function
 const main = async () => {
   const verbose = argv.verbose ? argv.verbose : false;
@@ -335,7 +423,19 @@ const main = async () => {
     dataDir = await promptDataDir();
   }
 
+  const isNonInteractive = !!(
+    argv['psych-ds-dir'] && await validateDirectory(argv['psych-ds-dir']) &&
+    argv['data-dir'] && await validateDirectory(argv['data-dir']) &&
+    argv['metadata-options'] && validateJson(argv['metadata-options'])
+  );
+
   if (verbose) console.log("\n\n-------------------------- Reading and writing data files --------------------------\n\n");
+
+  // Pre-pass: resolve Psych-DS-compliant output names, prompting once for any non-compliant
+  // filenames. Without an interactive terminal we cannot prompt, so this fails rather than
+  // inventing a keyword.
+  const canPrompt = !isNonInteractive && !!process.stdin.isTTY && !!process.stdout.isTTY;
+  const normalizedBases = await resolveFilenameNormalization(dataDir, canPrompt);
 
   // Pre-flight: check whether default join key (trial_index) is unique; prompt if not
   const initialKeys = ['trial_index'];
@@ -347,20 +447,14 @@ const main = async () => {
 
   // The pre-flight prompt above already surfaced any join-key uniqueness issue to the
   // user, so suppress the library's per-file warning to avoid repeating it.
-  await processDirectory(metadata, dataDir, verbose, `${project_path}/data`, { arrayJoinKeys, suppressJoinKeyWarning: true });
-  
+  await processDirectory(metadata, dataDir, verbose, `${project_path}/data`, { arrayJoinKeys, suppressJoinKeyWarning: true, normalizedBases });
+
   // check if it's a valid path and then prompt the options
   if (argv['metadata-options'] && validateJson(argv['metadata-options'])){
     if (verbose) console.log("\n\n-------------------------- Reading and writing metadata-option --------------------------n\n");
     await processOptions(metadata, argv['metadata-options'], verbose);
   }
   else await metadataOptionsPrompt(metadata, verbose); // passing in options file to overwite existing file
-  
-  const isNonInteractive = !!(
-    argv['psych-ds-dir'] && await validateDirectory(argv['psych-ds-dir']) &&
-    argv['data-dir'] && await validateDirectory(argv['data-dir']) &&
-    argv['metadata-options'] && validateJson(argv['metadata-options'])
-  );
 
   if (!isNonInteractive) await promptUnknownDescriptions(metadata);
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -46,7 +46,8 @@ export function deriveArrayFilename(sourceFile: string, columnName: string): str
 }
 
 /**
- * Serialises an array of flat objects to RFC 4180 CSV.
+ * Serialises an array of objects to RFC 4180 CSV. Nested objects/arrays in a cell
+ * are serialised as JSON strings so no data is lost.
  * trial_index and element_index columns are placed first; remaining columns
  * follow in the order they first appear across all rows.
  */
@@ -61,7 +62,10 @@ export function objectsToCSV(rows: Array<Record<string, any>>, priorityCols: str
   const headers = [...priorityCols.filter(c => allKeys.has(c)), ...otherCols];
 
   const escape = (val: any): string => {
-    const str = val === null || val === undefined ? '' : String(val);
+    if (val === null || val === undefined) return '';
+    // Preserve nested objects/arrays as JSON strings so no data is lost.
+    // (String(val) would collapse them to "[object Object]".)
+    const str = typeof val === 'object' ? JSON.stringify(val) : String(val);
     return str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')
       ? `"${str.replace(/"/g, '""')}"` : str;
   };

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -10,39 +10,51 @@ export function expandHomeDir(directoryPath: string): string {
 }
 
 /**
- * Converts a column name or file stem to a Psych-DS safe value segment:
- * lowercased; spaces, underscores, periods, and any other non-alphanumeric-hyphen
- * characters replaced with hyphens; runs of hyphens collapsed to one.
+ * Full Psych-DS data filename pattern, mirroring psychds-validator's fileRegex:
+ * one or more `keyword-value` pairs (keyword: lowercase letters only; value:
+ * alphanumeric, any case) joined by `_`, ending in `_data.csv` (or `.tsv`).
+ * Anything else fails validation with a FILENAME_KEYWORD_FORMATTING_ERROR.
  */
-export function sanitizePsychDSSegment(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9-]+/g, '-')
-    .replace(/-{2,}/g, '-')
-    .replace(/^-|-$/g, '');
+const PSYCH_DS_FILENAME_RE = /^([a-z]+-[a-zA-Z0-9]+)(_[a-z]+-[a-zA-Z0-9]+)*_data\.(csv|tsv)$/;
+
+/** True if `name` is a fully Psych-DS-compliant data filename. */
+export function isValidPsychDSDataFilename(name: string): boolean {
+  return PSYCH_DS_FILENAME_RE.test(name);
 }
 
 /**
- * Derives the Psych-DS compliant output filename for a separate array CSV.
- * Pattern: strip extension, strip trailing _data, sanitize, append _measure-{col}_data.csv
- *
- * "measure" is used as the key (rather than a structural label like "column") to align
- * with the Psych-DS / schema.org convention of describing data by what is measured.
- *
- * Examples:
- *   participant-001_session-1_data.csv + mouse_tracking_data
- *     → participant-001_session-1_measure-mouse-tracking-data_data.csv
- *   Keyboard Response.csv + response
- *     → keyboard-response_measure-response_data.csv
- *   stem + validation_data.pointData
- *     → stem_measure-validation-data-pointdata_data.csv
+ * Coerces an arbitrary string into a Psych-DS *value* segment ([a-zA-Z0-9]+).
+ * Psych-DS values forbid hyphens and underscores, so every run of non-alphanumeric
+ * characters is treated as a word boundary, removed, and the following word
+ * capitalised — yielding camelCase so meaning survives:
+ *   "mouse_tracking" → "mouseTracking", "subject1" → "subject1", "RT (ms)" → "RTMs".
+ * Returns `fallback` when the input has no alphanumeric characters.
  */
-export function deriveArrayFilename(sourceFile: string, columnName: string): string {
-  const stem = path.basename(sourceFile, path.extname(sourceFile));
-  const withoutData = stem.replace(/_data$/i, '');
-  const safeStem = sanitizePsychDSSegment(withoutData);
-  const safeCol = sanitizePsychDSSegment(columnName);
-  return `${safeStem}_measure-${safeCol}_data.csv`;
+export function toPsychDSValue(name: string, fallback = 'value'): string {
+  const parts = name.split(/[^a-zA-Z0-9]+/).filter(Boolean);
+  if (parts.length === 0) return fallback;
+  return parts[0] + parts.slice(1).map((p) => p[0].toUpperCase() + p.slice(1)).join('');
+}
+
+/**
+ * The "stem" of a source file: its basename minus the extension and a trailing `_data`.
+ * For an already-compliant file this is its Psych-DS base (the keyword-value sequence):
+ *   "subject-1_data.csv" → "subject-1",  "experiment.json" → "experiment".
+ */
+export function fileStem(file: string): string {
+  return path.basename(file, path.extname(file)).replace(/_data$/i, '');
+}
+
+/**
+ * Derives the Psych-DS filename for an extracted-array CSV from its parent file's
+ * already-normalized base plus the column name:
+ *   base "subject-subject1" + column "mouse_tracking"
+ *     → "subject-subject1_measure-mouseTracking_data.csv"
+ * "measure" is an unofficial Psych-DS keyword: it triggers a validator *warning*
+ * (not an error), used because no official keyword describes a per-column sub-table.
+ */
+export function deriveArrayFilename(parentBase: string, columnName: string): string {
+  return `${parentBase}_measure-${toPsychDSValue(columnName, 'col')}_data.csv`;
 }
 
 /**
@@ -79,13 +91,14 @@ export function objectsToCSV(rows: Array<Record<string, any>>, priorityCols: str
 
 /**
  * Returns a filename not already present in `used`. If `base` is free it is returned
- * as-is; otherwise a numeric suffix is inserted into the measure segment
- * (e.g. foo_measure-bar_data.csv → foo_measure-bar-2_data.csv) until a free name is found.
+ * as-is; otherwise a counter is appended directly to the final value
+ * (e.g. foo_measure-bar_data.csv → foo_measure-bar2_data.csv) until a free name is found.
  *
- * deriveArrayFilename is a lossy, many-to-one mapping (sanitization collapses separators,
- * and only the basename is used), so distinct source files / columns can produce the same
- * name. Since all extracted CSVs are written to a single flat directory, this prevents one
- * from silently overwriting another.
+ * The counter is appended with no separator on purpose: a hyphen or underscore would
+ * split into an extra/invalid keyword-value pair and fail the Psych-DS filename regex
+ * (values must be [a-zA-Z0-9]+). Distinct source files / columns can normalize to the
+ * same name (camelCase coercion is lossy, and only the basename is used), and since all
+ * outputs land in one flat directory this prevents one from silently overwriting another.
  */
 export function disambiguateArrayFilename(base: string, used: Set<string>): string {
   if (!used.has(base)) return base;
@@ -93,10 +106,30 @@ export function disambiguateArrayFilename(base: string, used: Set<string>): stri
   const suffix = '_data.csv';
   const root = base.endsWith(suffix) ? base.slice(0, -suffix.length) : base.replace(/\.csv$/i, '');
   let n = 2;
-  let candidate = `${root}-${n}${suffix}`;
+  let candidate = `${root}${n}${suffix}`;
   while (used.has(candidate)) {
     n += 1;
-    candidate = `${root}-${n}${suffix}`;
+    candidate = `${root}${n}${suffix}`;
+  }
+  return candidate;
+}
+
+/**
+ * Generic filename disambiguation: returns `name` unchanged when free, otherwise inserts
+ * a counter before the extension (e.g. data.json → data2.json) until a free name is found.
+ * Used for the preserved raw originals under data/raw/, whose basenames are not Psych-DS
+ * names and so are not constrained by the [a-zA-Z0-9] value rule.
+ */
+export function disambiguateFilename(name: string, used: Set<string>): string {
+  if (!used.has(name)) return name;
+
+  const ext = path.extname(name);
+  const stem = name.slice(0, name.length - ext.length);
+  let n = 2;
+  let candidate = `${stem}${n}${ext}`;
+  while (used.has(candidate)) {
+    n += 1;
+    candidate = `${stem}${n}${ext}`;
   }
   return candidate;
 }

--- a/packages/cli/tests/data.test.ts
+++ b/packages/cli/tests/data.test.ts
@@ -147,3 +147,73 @@ describe("processDirectory", () => {
     expect(metadata.getMetadataField("name")).toBe("Existing");
   });
 });
+
+describe("processDirectory JSON → CSV conversion", () => {
+  test("writes a converted CSV to data/ and preserves the original JSON under data/raw/", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    const dataDir = path.join(tmpDir, "data");
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(dataDir);
+
+    const rows = [
+      { trial_index: 0, rt: 200, response: { Q0: "yes" } },
+      { trial_index: 1, rt: 350, tags: ["a", "b"] },
+    ];
+    const original = JSON.stringify(rows);
+    fs.writeFileSync(path.join(srcDir, "experiment.json"), original);
+
+    const metadata = new JsPsychMetadata();
+    await processDirectory(metadata, srcDir, false, dataDir);
+
+    const csvPath = path.join(dataDir, "experiment.csv");
+    const rawPath = path.join(dataDir, "raw", "experiment.json");
+    expect(fs.existsSync(csvPath)).toBe(true);
+    expect(fs.existsSync(rawPath)).toBe(true);
+
+    // raw copy is byte-for-byte the original
+    expect(fs.readFileSync(rawPath, "utf8")).toBe(original);
+
+    // nested values are serialised as JSON, never "[object Object]"
+    const csv = fs.readFileSync(csvPath, "utf8");
+    expect(csv).not.toContain("[object Object]");
+    expect(csv).toContain('{""Q0"":""yes""}'); // escaped nested object
+    expect(csv).toContain('[""a"",""b""]');     // escaped nested array
+
+    // the original .json is not left behind in data/
+    expect(fs.existsSync(path.join(dataDir, "experiment.json"))).toBe(false);
+  });
+
+  test("does not convert or copy dataset_description.json into data/", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    const dataDir = path.join(tmpDir, "data");
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(dataDir);
+    fs.writeFileSync(
+      path.join(srcDir, "dataset_description.json"),
+      JSON.stringify({ name: "X", "@type": "Dataset", description: { default: "d" }, variableMeasured: [] }),
+    );
+
+    const metadata = new JsPsychMetadata();
+    await processDirectory(metadata, srcDir, false, dataDir);
+
+    expect(fs.existsSync(path.join(dataDir, "dataset_description.csv"))).toBe(false);
+    expect(fs.existsSync(path.join(dataDir, "raw", "dataset_description.json"))).toBe(false);
+  });
+
+  test("skips a second same-named JSON file instead of silently overwriting", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    const dataDir = path.join(tmpDir, "data");
+    fs.mkdirSync(path.join(srcDir, "a"), { recursive: true });
+    fs.mkdirSync(path.join(srcDir, "b"), { recursive: true });
+    fs.mkdirSync(dataDir);
+    fs.writeFileSync(path.join(srcDir, "a", "data.json"), JSON.stringify([{ trial_index: 0, rt: 1 }]));
+    fs.writeFileSync(path.join(srcDir, "b", "data.json"), JSON.stringify([{ trial_index: 0, rt: 2 }]));
+
+    const metadata = new JsPsychMetadata();
+    const { total, failed } = await processDirectory(metadata, srcDir, false, dataDir);
+
+    expect(total).toBe(2);
+    expect(failed).toBe(1); // the colliding second file is skipped, not overwritten
+    expect(fs.existsSync(path.join(dataDir, "data.csv"))).toBe(true);
+  });
+});

--- a/packages/cli/tests/data.test.ts
+++ b/packages/cli/tests/data.test.ts
@@ -162,10 +162,14 @@ describe("processDirectory JSON → CSV conversion", () => {
     const original = JSON.stringify(rows);
     fs.writeFileSync(path.join(srcDir, "experiment.json"), original);
 
-    const metadata = new JsPsychMetadata();
-    await processDirectory(metadata, srcDir, false, dataDir);
+    // mimic the CLI pre-pass: a non-compliant source name gets a resolved base
+    const normalizedBases = new Map([[path.resolve(srcDir, "experiment.json"), "subject-experiment"]]);
 
-    const csvPath = path.join(dataDir, "experiment.csv");
+    const metadata = new JsPsychMetadata();
+    await processDirectory(metadata, srcDir, false, dataDir, { normalizedBases });
+
+    // converted CSV is written under the resolved Psych-DS-compliant name
+    const csvPath = path.join(dataDir, "subject-experiment_data.csv");
     const rawPath = path.join(dataDir, "raw", "experiment.json");
     expect(fs.existsSync(csvPath)).toBe(true);
     expect(fs.existsSync(rawPath)).toBe(true);
@@ -200,7 +204,7 @@ describe("processDirectory JSON → CSV conversion", () => {
     expect(fs.existsSync(path.join(dataDir, "raw", "dataset_description.json"))).toBe(false);
   });
 
-  test("skips a second same-named JSON file instead of silently overwriting", async () => {
+  test("disambiguates a second same-named JSON file instead of overwriting or dropping it", async () => {
     const srcDir = path.join(tmpDir, "src");
     const dataDir = path.join(tmpDir, "data");
     fs.mkdirSync(path.join(srcDir, "a"), { recursive: true });
@@ -209,11 +213,84 @@ describe("processDirectory JSON → CSV conversion", () => {
     fs.writeFileSync(path.join(srcDir, "a", "data.json"), JSON.stringify([{ trial_index: 0, rt: 1 }]));
     fs.writeFileSync(path.join(srcDir, "b", "data.json"), JSON.stringify([{ trial_index: 0, rt: 2 }]));
 
+    // both source files resolve to the SAME base, forcing a collision in data/ and data/raw/
+    const normalizedBases = new Map([
+      [path.resolve(srcDir, "a", "data.json"), "subject-data"],
+      [path.resolve(srcDir, "b", "data.json"), "subject-data"],
+    ]);
+
+    const metadata = new JsPsychMetadata();
+    const { total, failed } = await processDirectory(metadata, srcDir, false, dataDir, { normalizedBases });
+
+    expect(total).toBe(2);
+    expect(failed).toBe(0); // both files are kept; the colliding one gets a disambiguated name
+    expect(fs.existsSync(path.join(dataDir, "subject-data_data.csv"))).toBe(true);
+    expect(fs.existsSync(path.join(dataDir, "subject-data2_data.csv"))).toBe(true);
+
+    // both raw originals are preserved distinctly (neither overwrites the other)
+    const rawDir = path.join(dataDir, "raw");
+    expect(fs.existsSync(path.join(rawDir, "data.json"))).toBe(true);
+    expect(fs.existsSync(path.join(rawDir, "data2.json"))).toBe(true);
+    const rawContents = fs.readdirSync(rawDir).map((f) => fs.readFileSync(path.join(rawDir, f), "utf8")).sort();
+    expect(rawContents).toEqual([
+      JSON.stringify([{ trial_index: 0, rt: 1 }]),
+      JSON.stringify([{ trial_index: 0, rt: 2 }]),
+    ]);
+  });
+
+  test("preserves an already-compliant CSV name and renames a non-compliant one to its resolved base", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    const dataDir = path.join(tmpDir, "data");
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(dataDir);
+    // subject-1_data.csv is already compliant → preserved via the fileStem fallback (no map entry needed);
+    // trial.csv is non-compliant → renamed using the resolved base from the pre-pass.
+    fs.writeFileSync(path.join(srcDir, "subject-1_data.csv"), "trial_type,rt\njsPsych-html-keyboard-response,450");
+    fs.writeFileSync(path.join(srcDir, "trial.csv"), "trial_type,rt\njsPsych-html-keyboard-response,512");
+
+    const normalizedBases = new Map([[path.resolve(srcDir, "trial.csv"), "subject-trial"]]);
+
+    const metadata = new JsPsychMetadata();
+    await processDirectory(metadata, srcDir, false, dataDir, { normalizedBases });
+
+    expect(fs.existsSync(path.join(dataDir, "subject-1_data.csv"))).toBe(true);
+    expect(fs.existsSync(path.join(dataDir, "subject-trial_data.csv"))).toBe(true);
+    expect(fs.existsSync(path.join(dataDir, "trial.csv"))).toBe(false);
+  });
+
+  test("skips a non-compliant filename when no normalized base is provided (never invents one)", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    const dataDir = path.join(tmpDir, "data");
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(dataDir);
+    fs.writeFileSync(path.join(srcDir, "experiment.json"), JSON.stringify([{ trial_index: 0, rt: 1 }]));
+    fs.writeFileSync(path.join(srcDir, "trial.csv"), "trial_type,rt\njsPsych-html-keyboard-response,512");
+
     const metadata = new JsPsychMetadata();
     const { total, failed } = await processDirectory(metadata, srcDir, false, dataDir);
 
+    // both are non-compliant and unmapped → skipped, not written under an invalid name
     expect(total).toBe(2);
-    expect(failed).toBe(1); // the colliding second file is skipped, not overwritten
-    expect(fs.existsSync(path.join(dataDir, "data.csv"))).toBe(true);
+    expect(failed).toBe(2);
+    expect(fs.readdirSync(dataDir).filter((f) => f.endsWith(".csv"))).toHaveLength(0);
+  });
+
+  test("names extracted-array CSVs from the parent's normalized base", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    const dataDir = path.join(tmpDir, "data");
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(dataDir);
+    // a nested array-of-objects column triggers extraction into a separate CSV
+    const rows = [
+      { trial_index: 0, mouse_tracking: [{ x: 1, y: 2 }, { x: 3, y: 4 }] },
+      { trial_index: 1, mouse_tracking: [{ x: 5, y: 6 }] },
+    ];
+    fs.writeFileSync(path.join(srcDir, "subject-1_data.json"), JSON.stringify(rows));
+
+    const metadata = new JsPsychMetadata();
+    await processDirectory(metadata, srcDir, false, dataDir);
+
+    // value is camelCased (no hyphens) and keyed by the unofficial "measure" keyword
+    expect(fs.existsSync(path.join(dataDir, "subject-1_measure-mouseTracking_data.csv"))).toBe(true);
   });
 });

--- a/packages/cli/tests/handlefiles.test.ts
+++ b/packages/cli/tests/handlefiles.test.ts
@@ -28,6 +28,12 @@ describe("createDirectoryWithStructure", () => {
     expect(fs.statSync(dataDir).isDirectory()).toBe(true);
   });
 
+  test("creates the nested data/raw/ directory", () => {
+    const rawDir = path.join(targetDir, "data", "raw");
+    expect(fs.existsSync(rawDir)).toBe(true);
+    expect(fs.statSync(rawDir).isDirectory()).toBe(true);
+  });
+
   test("creates README.md with expected content", () => {
     const readmePath = path.join(targetDir, "README.md");
     expect(fs.existsSync(readmePath)).toBe(true);
@@ -50,6 +56,7 @@ describe("createDirectoryWithStructure", () => {
     expect(fs.existsSync(nested)).toBe(true);
     expect(fs.statSync(nested).isDirectory()).toBe(true);
     expect(fs.existsSync(path.join(nested, "data"))).toBe(true);
+    expect(fs.existsSync(path.join(nested, "data", "raw"))).toBe(true);
     expect(fs.existsSync(path.join(nested, "README.md"))).toBe(true);
     expect(fs.existsSync(path.join(nested, "CHANGES.md"))).toBe(true);
   });

--- a/packages/cli/tests/utils.test.ts
+++ b/packages/cli/tests/utils.test.ts
@@ -1,6 +1,6 @@
 import os from "os";
 import path from "path";
-import { expandHomeDir } from "../src/utils";
+import { expandHomeDir, objectsToCSV } from "../src/utils";
 import { generatePath } from "../src/data";
 
 describe("expandHomeDir", () => {
@@ -31,5 +31,38 @@ describe("generatePath", () => {
   test("resolves a relative path against the current working directory", () => {
     const relative = "relative/path";
     expect(generatePath(relative)).toBe(path.resolve(process.cwd(), relative));
+  });
+});
+
+describe("objectsToCSV", () => {
+  test("returns an empty string for no rows", () => {
+    expect(objectsToCSV([])).toBe("");
+  });
+
+  test("places priority columns first, then remaining columns in first-seen order", () => {
+    const csv = objectsToCSV([{ rt: 5, trial_index: 0 }], ["trial_index"]);
+    expect(csv.split("\r\n")[0]).toBe("trial_index,rt");
+  });
+
+  test("serialises nested objects/arrays as JSON, never [object Object]", () => {
+    const csv = objectsToCSV([{ trial_index: 0, response: { Q0: "yes" }, tags: ["a", "b"] }], ["trial_index"]);
+    expect(csv).not.toContain("[object Object]");
+    expect(csv).toContain('{""Q0"":""yes""}'); // escaped JSON object
+    expect(csv).toContain('[""a"",""b""]');     // escaped JSON array
+  });
+
+  test("escapes commas, quotes, and newlines per RFC 4180", () => {
+    const csv = objectsToCSV([{ a: "x,y", b: 'say "hi"', c: "two\nlines" }], []);
+    expect(csv).toContain('"x,y"');
+    expect(csv).toContain('"say ""hi"""');
+    expect(csv).toContain('"two\nlines"');
+  });
+
+  test("leaves missing fields as empty cells (header is the union of all keys)", () => {
+    const csv = objectsToCSV([{ a: 1, b: 2 }, { a: 3 }], []);
+    const lines = csv.split("\r\n");
+    expect(lines[0]).toBe("a,b");
+    expect(lines[1]).toBe("1,2");
+    expect(lines[2]).toBe("3,");
   });
 });

--- a/packages/cli/tests/utils.test.ts
+++ b/packages/cli/tests/utils.test.ts
@@ -1,6 +1,15 @@
 import os from "os";
 import path from "path";
-import { expandHomeDir, objectsToCSV } from "../src/utils";
+import {
+  expandHomeDir,
+  objectsToCSV,
+  isValidPsychDSDataFilename,
+  toPsychDSValue,
+  fileStem,
+  deriveArrayFilename,
+  disambiguateArrayFilename,
+  disambiguateFilename,
+} from "../src/utils";
 import { generatePath } from "../src/data";
 
 describe("expandHomeDir", () => {
@@ -64,5 +73,105 @@ describe("objectsToCSV", () => {
     expect(lines[0]).toBe("a,b");
     expect(lines[1]).toBe("1,2");
     expect(lines[2]).toBe("3,");
+  });
+});
+
+describe("isValidPsychDSDataFilename", () => {
+  test("accepts compliant single- and multi-pair names", () => {
+    expect(isValidPsychDSDataFilename("study-minimal_data.csv")).toBe(true);
+    expect(isValidPsychDSDataFilename("subject-001_session-1_data.csv")).toBe(true);
+    expect(isValidPsychDSDataFilename("subject-123a_data.tsv")).toBe(true);
+  });
+
+  test("rejects non-compliant names", () => {
+    expect(isValidPsychDSDataFilename("subject1_data.csv")).toBe(false);   // no key-value pair
+    expect(isValidPsychDSDataFilename("experiment.csv")).toBe(false);      // missing _data
+    expect(isValidPsychDSDataFilename("year2024_data.csv")).toBe(false);   // no hyphen
+    expect(isValidPsychDSDataFilename("subject-a-b_data.csv")).toBe(false); // hyphen in value
+    expect(isValidPsychDSDataFilename("sub1-1_data.csv")).toBe(false);     // digit in keyword
+  });
+});
+
+describe("toPsychDSValue", () => {
+  test("camelCases across non-alphanumeric boundaries", () => {
+    expect(toPsychDSValue("mouse_tracking")).toBe("mouseTracking");
+    expect(toPsychDSValue("mouse-tracking-data")).toBe("mouseTrackingData");
+    expect(toPsychDSValue("My Data")).toBe("MyData");
+  });
+
+  test("leaves already-alphanumeric strings intact", () => {
+    expect(toPsychDSValue("subject1")).toBe("subject1");
+    expect(toPsychDSValue("responseTime")).toBe("responseTime");
+  });
+
+  test("returns the fallback when there are no alphanumeric characters", () => {
+    expect(toPsychDSValue("___")).toBe("value");
+    expect(toPsychDSValue("!!!", "col")).toBe("col");
+  });
+
+  test("output is always a valid Psych-DS value segment", () => {
+    for (const input of ["mouse_tracking", "RT (ms)", "a-b-c", "x.y.z"]) {
+      expect(toPsychDSValue(input)).toMatch(/^[a-zA-Z0-9]+$/);
+    }
+  });
+});
+
+describe("fileStem", () => {
+  test("strips extension and a trailing _data", () => {
+    expect(fileStem("subject-1_data.csv")).toBe("subject-1");
+    expect(fileStem("experiment.json")).toBe("experiment");
+    expect(fileStem("trial.csv")).toBe("trial");
+  });
+});
+
+describe("deriveArrayFilename", () => {
+  test("builds a valid name from the parent base and column", () => {
+    const name = deriveArrayFilename("subject-subject1", "mouse_tracking");
+    expect(name).toBe("subject-subject1_measure-mouseTracking_data.csv");
+    expect(isValidPsychDSDataFilename(name)).toBe(true);
+  });
+
+  test("coerces hyphenated columns to a valid (hyphen-free) value", () => {
+    const name = deriveArrayFilename("study-minimal", "validation-data.pointData");
+    expect(isValidPsychDSDataFilename(name)).toBe(true);
+  });
+});
+
+describe("disambiguateArrayFilename", () => {
+  test("returns the name unchanged when free", () => {
+    expect(disambiguateArrayFilename("subject-1_data.csv", new Set())).toBe("subject-1_data.csv");
+  });
+
+  test("appends a counter to the final value, keeping the name valid", () => {
+    const used = new Set(["subject-1_data.csv"]);
+    const next = disambiguateArrayFilename("subject-1_data.csv", used);
+    expect(next).toBe("subject-12_data.csv");
+    expect(isValidPsychDSDataFilename(next)).toBe(true);
+  });
+
+  test("skips already-used counters", () => {
+    const used = new Set(["x-a_data.csv", "x-a2_data.csv"]);
+    expect(disambiguateArrayFilename("x-a_data.csv", used)).toBe("x-a3_data.csv");
+  });
+});
+
+describe("disambiguateFilename", () => {
+  test("returns the name unchanged when free", () => {
+    expect(disambiguateFilename("data.json", new Set())).toBe("data.json");
+  });
+
+  test("inserts a counter before the extension on collision", () => {
+    const used = new Set(["data.json"]);
+    expect(disambiguateFilename("data.json", used)).toBe("data2.json");
+  });
+
+  test("skips already-used counters", () => {
+    const used = new Set(["data.json", "data2.json"]);
+    expect(disambiguateFilename("data.json", used)).toBe("data3.json");
+  });
+
+  test("handles names without an extension", () => {
+    const used = new Set(["README"]);
+    expect(disambiguateFilename("README", used)).toBe("README2");
   });
 });


### PR DESCRIPTION
## What

Converts jsPsych JSON data files to CSV when building a Psych-DS project, **and normalizes all generated data filenames** to the Psych-DS `[keyword-value_]+data.csv` pattern, so the generated dataset passes the Psych-DS validator (which expects CSV data files with compliant names).

When processing a data directory, each `.json` data file is now:
- written as a `.csv` in `data/` — nested objects/arrays are serialized as JSON strings via `objectsToCSV`, so **no data is lost** (previously nested cells would have become `[object Object]`);
- preserved byte-for-byte as the original under `data/raw/`.

`.csv` inputs are written through to `data/` under their compliant name; `dataset_description.json` is copied unchanged.

## Filename normalization

Output filenames follow the Psych-DS naming pattern:
- Already-compliant names are kept as-is.
- For non-compliant names, the CLI prompts **once** for a keyword (official keywords are offered to avoid the validator's unofficial-keyword warning; custom keywords are allowed), with the file's current stem becoming the value (camelCased, since Psych-DS values forbid hyphens/underscores).
- The same normalized base names the converted/copied CSV **and** its extracted-array CSVs, fixing previously invalid extracted-array names.
- In a **non-interactive** run, a non-compliant filename is a hard error rather than a silently invented keyword.
- Same-named source files from different subdirectories are disambiguated with a validator-safe counter (both the `data/` CSV and the `data/raw/` original), instead of being skipped or silently overwritten.

## Details

- **`handlefiles.ts`** — the scaffold builder is now recursive and creates the nested `data/raw/` directory (the old single-level builder couldn't create nested dirs).
- **`utils.ts`** — `objectsToCSV` serializes nested objects/arrays as JSON strings instead of `String(val)`. Adds `isValidPsychDSDataFilename`, `toPsychDSValue`, `fileStem`, and `disambiguateFilename`; reworks `deriveArrayFilename`/`disambiguateArrayFilename` so disambiguation counters stay regex-valid.
- **`index.ts`** — a pre-pass (`resolveFilenameNormalization`) resolves a compliant base for every data file, prompting once for any non-compliant names; the non-interactive check is hoisted earlier in `main()` so the pre-pass can fail fast.
- **`data.ts`** — `processFile` performs the conversion/copy + raw preservation under the normalized names; `dataset_description.json` is left untouched; `enumerateDataFiles` feeds the pre-pass.

## Tests

- `tests/handlefiles.test.ts` — verifies `data/` and nested `data/raw/`.
- `tests/utils.test.ts` — `objectsToCSV` (nested→JSON, priority columns, RFC-4180 escaping, key union), plus `isValidPsychDSDataFilename`, `toPsychDSValue`, `fileStem`, `deriveArrayFilename`, and the `disambiguate*` helpers.
- `tests/data.test.ts` — conversion + raw preservation, `dataset_description.json` left alone, collision disambiguation, compliant/non-compliant naming, skip-when-unmapped, and extracted-array naming.

Typecheck clean, bundle builds, full monorepo suite passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
