### PR TITLE
feat(cli): exit code 1 on validation errors; re-prompt for missing required fields

### DIFF
--- a/.changeset/validation-exit-code.md
+++ b/.changeset/validation-exit-code.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata-cli": minor
+---
+
+Exit code 1 on validation errors; re-prompt for missing required fields; suggest missing recommended fields.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -385,10 +385,10 @@ const main = async () => {
         const updatedMetadata = JSON.stringify(metadata.getMetadata(), null, 2);
         await saveTextToPath(updatedMetadata, `${project_path}/dataset_description.json`);
         const revalidation = await validatePsychDS(project_path, verbose);
+        if (revalidation.hasErrors) process.exit(1);
         if (revalidation.missingRecommendedFields.length > 0) {
           console.log(`\nConsider adding these recommended fields to your metadata: ${revalidation.missingRecommendedFields.join(', ')}`);
         }
-        if (revalidation.hasErrors) process.exit(1);
       } else {
         process.exit(1);
       }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -313,7 +313,7 @@ const main = async () => {
       new_project = false;
       await loadMetadata(metadata, project_path + "/dataset_description.json"); // maybe shoudl add verbose
       // project_path is argv['psych-ds-dir'] (a string) inside this branch — no typeof guard needed here.
-      await validatePsychDS(project_path, verbose);
+      await validatePsychDS(project_path, verbose); // informational only — result not acted on here
       if (verbose) console.log(`\n\n-------------------------- Reading existing metadata --------------------------\n\n${JSON.stringify(metadata.getMetadata(), null, 2)}`);
   }
   else {
@@ -371,22 +371,31 @@ const main = async () => {
   if (typeof project_path === 'string') {
     const validation = await validatePsychDS(project_path, verbose);
 
-    if (validation.missingRecommendedFields.length > 0) {
-      console.log(`\nConsider adding these recommended fields to your metadata: ${validation.missingRecommendedFields.join(', ')}`);
-    }
-
     if (validation.missingRequiredFields.length > 0) {
-      console.log('\nSome required fields are missing. Please provide values:');
-      for (const field of validation.missingRequiredFields) {
-        const value = await input({ message: `Value for required field "${field}":` });
-        if (value.trim()) metadata.setMetadataField(field, value.trim());
+      if (!isNonInteractive) {
+        console.log('\nSome required fields are missing. Please provide values:');
+        for (const field of validation.missingRequiredFields) {
+          const value = await input({ message: `Value for required field "${field}":` });
+          if (value.trim()) {
+            metadata.setMetadataField(field, value.trim());
+          } else {
+            console.warn(`  Skipped "${field}" — this field is still required. Validation may still fail.`);
+          }
+        }
+        const updatedMetadata = JSON.stringify(metadata.getMetadata(), null, 2);
+        await saveTextToPath(updatedMetadata, `${project_path}/dataset_description.json`);
+        const revalidation = await validatePsychDS(project_path, verbose);
+        if (revalidation.missingRecommendedFields.length > 0) {
+          console.log(`\nConsider adding these recommended fields to your metadata: ${revalidation.missingRecommendedFields.join(', ')}`);
+        }
+        if (revalidation.hasErrors) process.exit(1);
+      } else {
+        process.exit(1);
       }
-      const updatedMetadata = JSON.stringify(metadata.getMetadata(), null, 2);
-      await saveTextToPath(updatedMetadata, `${project_path}/dataset_description.json`);
-      const revalidation = await validatePsychDS(project_path, verbose);
-      if (revalidation.hasErrors) process.exit(1);
     } else if (validation.hasErrors) {
       process.exit(1);
+    } else if (validation.missingRecommendedFields.length > 0) {
+      console.log(`\nConsider adding these recommended fields to your metadata: ${validation.missingRecommendedFields.join(', ')}`);
     }
   }
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -367,7 +367,28 @@ const main = async () => {
   const metadataString = JSON.stringify(metadata.getMetadata(), null, 2); // Assuming getMetadata() is the function that retrieves your metadata
   if (argv.verbose) console.log("\n\n-------------------------- Final metadata string --------------------------\n\n", metadataString);
   await saveTextToPath(metadataString,`${project_path}/dataset_description.json`);
-  if (typeof project_path === 'string') await validatePsychDS(project_path, verbose);
+
+  if (typeof project_path === 'string') {
+    const validation = await validatePsychDS(project_path, verbose);
+
+    if (validation.missingRecommendedFields.length > 0) {
+      console.log(`\nConsider adding these recommended fields to your metadata: ${validation.missingRecommendedFields.join(', ')}`);
+    }
+
+    if (validation.missingRequiredFields.length > 0) {
+      console.log('\nSome required fields are missing. Please provide values:');
+      for (const field of validation.missingRequiredFields) {
+        const value = await input({ message: `Value for required field "${field}":` });
+        if (value.trim()) metadata.setMetadataField(field, value.trim());
+      }
+      const updatedMetadata = JSON.stringify(metadata.getMetadata(), null, 2);
+      await saveTextToPath(updatedMetadata, `${project_path}/dataset_description.json`);
+      const revalidation = await validatePsychDS(project_path, verbose);
+      if (revalidation.hasErrors) process.exit(1);
+    } else if (validation.hasErrors) {
+      process.exit(1);
+    }
+  }
 };
 
 main();

--- a/packages/cli/src/validatefunctions.ts
+++ b/packages/cli/src/validatefunctions.ts
@@ -3,13 +3,28 @@ import path from "path";
 import { expandHomeDir } from "./utils";
 import { validate } from "psychds-validator";
 
-export const validatePsychDS = async (datasetPath: string, verbose: boolean): Promise<void> => {
+export interface PsychDSValidationResult {
+  hasErrors: boolean;
+  missingRequiredFields: string[];
+  missingRecommendedFields: string[];
+}
+
+function parseMissingFields(issues: Map<string, any>, key: string): string[] {
+  const issue = issues.get(key);
+  if (!issue) return [];
+  const firstFile = Array.from(issue.files.values())[0] as any;
+  const evidence: string = firstFile?.evidence ?? '';
+  const match = evidence.match(/\[([^\]]+)\]/);
+  return match ? match[1].split(',').map((f: string) => f.trim()).filter(Boolean) : [];
+}
+
+export const validatePsychDS = async (datasetPath: string, verbose: boolean): Promise<PsychDSValidationResult> => {
   let result;
   try {
     result = await validate(path.relative(process.cwd(), datasetPath));
   } catch (err) {
     console.warn(`\nWarning: Psych-DS validation could not run: ${err instanceof Error ? err.message : err}`);
-    return;
+    return { hasErrors: false, missingRequiredFields: [], missingRecommendedFields: [] };
   }
 
   const errors: string[] = [];
@@ -33,6 +48,12 @@ export const validatePsychDS = async (datasetPath: string, verbose: boolean): Pr
   } else if (!verbose && warnings.length > 0) {
     console.log("  (Rerun with --verbose to see warnings.)");
   }
+
+  return {
+    hasErrors: errors.length > 0,
+    missingRequiredFields: parseMissingFields(result.issues, 'JSON_KEY_REQUIRED'),
+    missingRecommendedFields: parseMissingFields(result.issues, 'JSON_KEY_RECOMMENDED'),
+  };
 };
 
 // Validating if input is a directory

--- a/packages/cli/src/validatefunctions.ts
+++ b/packages/cli/src/validatefunctions.ts
@@ -9,13 +9,20 @@ export interface PsychDSValidationResult {
   missingRecommendedFields: string[];
 }
 
-function parseMissingFields(issues: Map<string, any>, key: string): string[] {
+export function parseMissingFields(issues: Map<string, any>, key: string): string[] {
   const issue = issues.get(key);
   if (!issue) return [];
-  const firstFile = Array.from(issue.files.values())[0] as any;
-  const evidence: string = firstFile?.evidence ?? '';
-  const match = evidence.match(/\[([^\]]+)\]/);
-  return match ? match[1].split(',').map((f: string) => f.trim()).filter(Boolean) : [];
+  const fields = new Set<string>();
+  for (const file of issue.files.values()) {
+    const evidence: string = (file as any)?.evidence ?? '';
+    const match = evidence.match(/\[([^\]]+)\]/);
+    if (match) {
+      match[1].split(',').map((f: string) => f.trim()).filter(Boolean).forEach(f => fields.add(f));
+    } else if (evidence) {
+      console.warn(`Warning: could not parse missing fields from validator evidence: ${evidence}`);
+    }
+  }
+  return [...fields];
 }
 
 export const validatePsychDS = async (datasetPath: string, verbose: boolean): Promise<PsychDSValidationResult> => {

--- a/packages/cli/tests/validatefunctions.test.ts
+++ b/packages/cli/tests/validatefunctions.test.ts
@@ -1,7 +1,57 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { validateDirectory, validateJson } from "../src/validatefunctions";
+import { validateDirectory, validateJson, parseMissingFields } from "../src/validatefunctions";
+
+function makeIssues(key: string, files: Array<{ evidence: string }>): Map<string, any> {
+  const filesMap = new Map(files.map((f, i) => [`/path${i}`, f]));
+  return new Map([[key, { files: filesMap }]]);
+}
+
+describe("parseMissingFields", () => {
+  test("returns empty array when key is not in issues", () => {
+    expect(parseMissingFields(new Map(), "JSON_KEY_REQUIRED")).toEqual([]);
+  });
+
+  test("parses a single missing field from one file", () => {
+    const issues = makeIssues("JSON_KEY_REQUIRED", [
+      { evidence: "metadata object missing fields: [name] as per ..." },
+    ]);
+    expect(parseMissingFields(issues, "JSON_KEY_REQUIRED")).toEqual(["name"]);
+  });
+
+  test("parses multiple missing fields from one file", () => {
+    const issues = makeIssues("JSON_KEY_REQUIRED", [
+      { evidence: "metadata object missing fields: [name,description,author] as per ..." },
+    ]);
+    expect(parseMissingFields(issues, "JSON_KEY_REQUIRED")).toEqual(["name", "description", "author"]);
+  });
+
+  test("unions fields across multiple files and deduplicates", () => {
+    const issues = makeIssues("JSON_KEY_REQUIRED", [
+      { evidence: "metadata object missing fields: [name,description] as per ..." },
+      { evidence: "metadata object missing fields: [description,author] as per ..." },
+    ]);
+    expect(parseMissingFields(issues, "JSON_KEY_REQUIRED")).toEqual(["name", "description", "author"]);
+  });
+
+  test("returns empty array and warns when evidence is non-empty but unparseable", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const issues = makeIssues("JSON_KEY_REQUIRED", [{ evidence: "unexpected format" }]);
+    const result = parseMissingFields(issues, "JSON_KEY_REQUIRED");
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("could not parse missing fields"));
+    warnSpy.mockRestore();
+  });
+
+  test("returns empty array silently when evidence is empty", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const issues = makeIssues("JSON_KEY_REQUIRED", [{ evidence: "" }]);
+    expect(parseMissingFields(issues, "JSON_KEY_REQUIRED")).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
 
 // Each test suite gets its own temp directory, cleaned up after all tests in the suite.
 describe("validateDirectory", () => {


### PR DESCRIPTION
## Summary

- `validatePsychDS` now returns a structured `PsychDSValidationResult` (`hasErrors`, `missingRequiredFields`, `missingRecommendedFields`) instead of `void`
- After final validation, if `JSON_KEY_REQUIRED` errors are present: re-prompts the user selectively for each missing field by name, re-saves, and re-validates
- If `JSON_KEY_RECOMMENDED` warnings are present: prints a suggestion without forcing a re-prompt
- Exits with code 1 if errors remain after the re-prompt attempt (or immediately if errors are non-remediable)
- The first `validatePsychDS` call (loading an existing project) is informational only — no re-prompt or exit code there

Missing fields are parsed from the `JSON_KEY_REQUIRED`/`JSON_KEY_RECOMMENDED` evidence strings emitted by the validator (`metadata object missing fields: [field1, field2] as per ...`). This parsing is noted as a potential fragility if the upstream evidence format changes.

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 32 existing tests pass (`npx jest`)
- [ ] Manual: run CLI on a dataset missing a required field — should re-prompt then re-validate
- [ ] Manual: run CLI on a dataset missing only recommended fields — should suggest without blocking
- [ ] Manual: run CLI on a dataset with non-remediable errors — should exit 1

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)