### PR TITLE
test(cli): unit tests for validatePsychDS

### DIFF
--- a/.changeset/cli-test-validate-psych-ds.md
+++ b/.changeset/cli-test-validate-psych-ds.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata-cli": patch
+---
+
+Add unit tests for validatePsychDS covering clean pass, errors, warnings (verbose and non-verbose), plural forms, and validator-throws scenarios.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
       },
       "devDependencies": {
         "@changesets/cli": "^2.27.7",
-        "@types/jest": "^30.0.0",
         "esbuild": "0.23.0",
         "jest": "^29.7.0"
       }
@@ -2458,16 +2457,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@jest/diff-sequences": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
-      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -2525,16 +2514,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/get-type": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
-      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -2548,30 +2527,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/pattern": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-regex-util": "30.4.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -4492,308 +4447,6 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jest": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
-      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^30.0.0",
-        "pretty-format": "^30.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
-      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@jest/types": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.4.0",
-        "@jest/schemas": "30.4.1",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/jest/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@types/jest/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@types/jest/node_modules/ci-info": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@types/jest/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/jest/node_modules/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-diff": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
-      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/diff-sequences": "30.4.0",
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
-      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "jest-diff": "30.4.1",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-message-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.4.1",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "jest-util": "30.4.1",
-        "picomatch": "^4.0.3",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-mock": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@types/jest/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@types/jsdom": {
@@ -12822,22 +12475,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
-    },
-    "node_modules/react-is-18": {
-      "name": "react-is",
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/react-is-19": {
-      "name": "react-is",
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/read-yaml-file": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@changesets/cli": "^2.27.7",
+        "@types/jest": "^30.0.0",
         "esbuild": "0.23.0",
         "jest": "^29.7.0"
       }
@@ -2457,6 +2458,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -2514,6 +2525,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -2527,6 +2548,30 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -4450,13 +4495,305 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.12",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
-      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@types/jsdom": {
@@ -4606,10 +4943,11 @@
       "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.32",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -12485,6 +12823,22 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/read-yaml-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
@@ -14750,8 +15104,37 @@
       "devDependencies": {
         "@sucrase/jest-plugin": "^3.0.0",
         "@types/jest": "^29.5.12",
+        "@types/node": "^20.0.0",
         "jest": "^29.7.0"
       }
+    },
+    "packages/cli/node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "packages/cli/node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/cli/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/frontend": {
       "version": "0.0.2",
@@ -15259,6 +15642,17 @@
         "husky": "^9.0.11",
         "ts-jest": "^29.1.4",
         "typescript": "^5.5.4"
+      }
+    },
+    "packages/metadata/node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     }
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@sucrase/jest-plugin": "^3.0.0",
     "@types/jest": "^29.5.12",
+    "@types/node": "^20.0.0",
     "jest": "^29.7.0"
   },
   "dependencies": {

--- a/packages/cli/tests/validatefunctions.test.ts
+++ b/packages/cli/tests/validatefunctions.test.ts
@@ -82,32 +82,38 @@ describe("validatePsychDS", () => {
 
   test("prints ✔ line when validation passes with no warnings", async () => {
     mockValidate.mockResolvedValue(makeResult([]));
-    await validatePsychDS("/some/dataset", false);
+    const result = await validatePsychDS("/some/dataset", false);
     expect(mockValidate).toHaveBeenCalledWith(path.relative(process.cwd(), "/some/dataset"));
     expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (0 warnings).");
     expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ hasErrors: false, missingRequiredFields: [], missingRecommendedFields: [] });
   });
 
   test("prints ✘ line and each error when errors are present", async () => {
     mockValidate.mockResolvedValue(makeResult([
       { severity: "error", key: "MISSING_FIELD", reason: "field is required" },
     ]));
-    await validatePsychDS("/some/dataset", false);
+    const result = await validatePsychDS("/some/dataset", false);
     expect(errorSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 0 warnings.\n");
     expect(errorSpy).toHaveBeenCalledWith("  Error 1: MISSING_FIELD: field is required");
     expect(errorSpy).toHaveBeenCalledTimes(2);
     expect(logSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ hasErrors: true, missingRequiredFields: [], missingRecommendedFields: [] });
   });
 
-  test("prints only error lines when errors are present and verbose is true", async () => {
+  test("suppresses warning details but shows rerun hint when errors and warnings are present and verbose is false", async () => {
     mockValidate.mockResolvedValue(makeResult([
       { severity: "error", key: "MISSING_FIELD", reason: "field is required" },
+      { severity: "warning", key: "OPTIONAL_MISSING", reason: "optional field absent" },
     ]));
-    await validatePsychDS("/some/dataset", true);
-    expect(errorSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 0 warnings.\n");
+    const result = await validatePsychDS("/some/dataset", false);
+    expect(errorSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 1 warning.\n");
     expect(errorSpy).toHaveBeenCalledWith("  Error 1: MISSING_FIELD: field is required");
     expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith("  (Rerun with --verbose to see warnings.)");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ hasErrors: true, missingRequiredFields: [], missingRecommendedFields: [] });
   });
 
   test("prints rerun hint when warnings are present and verbose is false", async () => {

--- a/packages/cli/tests/validatefunctions.test.ts
+++ b/packages/cli/tests/validatefunctions.test.ts
@@ -2,8 +2,88 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { validateDirectory, validateJson } from "../src/validatefunctions";
+import type { validatePsychDS as ValidatePsychDSType } from "../src/validatefunctions";
 
 // Each test suite gets its own temp directory, cleaned up after all tests in the suite.
+function makeResult(issues: Array<{ severity: string; key: string; reason: string }>) {
+  return { issues: new Map(issues.map((issue, i) => [String(i), issue])) };
+}
+
+describe("validatePsychDS", () => {
+  let validatePsychDS: typeof ValidatePsychDSType;
+  let mockValidate: jest.Mock;
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockValidate = jest.fn();
+    jest.doMock("psychds-validator", () => ({ validate: mockValidate }));
+    ({ validatePsychDS } = require("../src/validatefunctions"));
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("prints ✔ line when validation passes with no warnings", async () => {
+    mockValidate.mockResolvedValue(makeResult([]));
+    await validatePsychDS("/some/dataset", false);
+    expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (0 warnings).");
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("prints ✘ line and each error when errors are present", async () => {
+    mockValidate.mockResolvedValue(makeResult([
+      { severity: "error", key: "MISSING_FIELD", reason: "field is required" },
+    ]));
+    await validatePsychDS("/some/dataset", false);
+    expect(logSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 0 warnings.\n");
+    expect(logSpy).toHaveBeenCalledWith("  Error 1: MISSING_FIELD: field is required");
+  });
+
+  test("prints rerun hint when warnings are present and verbose is false", async () => {
+    mockValidate.mockResolvedValue(makeResult([
+      { severity: "warning", key: "OPTIONAL_MISSING", reason: "optional field absent" },
+    ]));
+    await validatePsychDS("/some/dataset", false);
+    expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (1 warning).");
+    expect(logSpy).toHaveBeenCalledWith("  (Rerun with --verbose to see warnings.)");
+  });
+
+  test("prints each warning when warnings are present and verbose is true", async () => {
+    mockValidate.mockResolvedValue(makeResult([
+      { severity: "warning", key: "OPTIONAL_MISSING", reason: "optional field absent" },
+    ]));
+    await validatePsychDS("/some/dataset", true);
+    expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (1 warning).");
+    expect(logSpy).toHaveBeenCalledWith("  Warning 1: OPTIONAL_MISSING: optional field absent");
+  });
+
+  test("uses correct plurals with multiple errors and warnings", async () => {
+    mockValidate.mockResolvedValue(makeResult([
+      { severity: "error", key: "ERR1", reason: "reason one" },
+      { severity: "error", key: "ERR2", reason: "reason two" },
+      { severity: "warning", key: "WARN1", reason: "warn reason" },
+    ]));
+    await validatePsychDS("/some/dataset", false);
+    expect(logSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 2 errors, 1 warning.\n");
+    expect(logSpy).toHaveBeenCalledWith("  Error 1: ERR1: reason one");
+    expect(logSpy).toHaveBeenCalledWith("  Error 2: ERR2: reason two");
+  });
+
+  test("prints console.warn and returns without crashing when validate throws", async () => {
+    mockValidate.mockRejectedValue(new Error("validator failed"));
+    await expect(validatePsychDS("/some/dataset", false)).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "\nWarning: Psych-DS validation could not run: validator failed"
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("validateDirectory", () => {
   let tmpDir: string;
 

--- a/packages/cli/tests/validatefunctions.test.ts
+++ b/packages/cli/tests/validatefunctions.test.ts
@@ -1,8 +1,58 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { validateDirectory, validateJson } from "../src/validatefunctions";
+import { validateDirectory, validateJson, parseMissingFields } from "../src/validatefunctions";
 import type { validatePsychDS as ValidatePsychDSType } from "../src/validatefunctions";
+
+function makeIssues(key: string, files: Array<{ evidence: string }>): Map<string, any> {
+  const filesMap = new Map(files.map((f, i) => [`/path${i}`, f]));
+  return new Map([[key, { files: filesMap }]]);
+}
+
+describe("parseMissingFields", () => {
+  test("returns empty array when key is not in issues", () => {
+    expect(parseMissingFields(new Map(), "JSON_KEY_REQUIRED")).toEqual([]);
+  });
+
+  test("parses a single missing field from one file", () => {
+    const issues = makeIssues("JSON_KEY_REQUIRED", [
+      { evidence: "metadata object missing fields: [name] as per ..." },
+    ]);
+    expect(parseMissingFields(issues, "JSON_KEY_REQUIRED")).toEqual(["name"]);
+  });
+
+  test("parses multiple missing fields from one file", () => {
+    const issues = makeIssues("JSON_KEY_REQUIRED", [
+      { evidence: "metadata object missing fields: [name,description,author] as per ..." },
+    ]);
+    expect(parseMissingFields(issues, "JSON_KEY_REQUIRED")).toEqual(["name", "description", "author"]);
+  });
+
+  test("unions fields across multiple files and deduplicates", () => {
+    const issues = makeIssues("JSON_KEY_REQUIRED", [
+      { evidence: "metadata object missing fields: [name,description] as per ..." },
+      { evidence: "metadata object missing fields: [description,author] as per ..." },
+    ]);
+    expect(parseMissingFields(issues, "JSON_KEY_REQUIRED")).toEqual(["name", "description", "author"]);
+  });
+
+  test("returns empty array and warns when evidence is non-empty but unparseable", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const issues = makeIssues("JSON_KEY_REQUIRED", [{ evidence: "unexpected format" }]);
+    const result = parseMissingFields(issues, "JSON_KEY_REQUIRED");
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("could not parse missing fields"));
+    warnSpy.mockRestore();
+  });
+
+  test("returns empty array silently when evidence is empty", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const issues = makeIssues("JSON_KEY_REQUIRED", [{ evidence: "" }]);
+    expect(parseMissingFields(issues, "JSON_KEY_REQUIRED")).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
 
 // Each test suite gets its own temp directory, cleaned up after all tests in the suite.
 function makeResult(issues: Array<{ severity: string; key: string; reason: string }>) {
@@ -14,6 +64,7 @@ describe("validatePsychDS", () => {
   let mockValidate: jest.Mock;
   let logSpy: jest.SpyInstance;
   let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.resetModules();
@@ -22,6 +73,7 @@ describe("validatePsychDS", () => {
     ({ validatePsychDS } = require("../src/validatefunctions"));
     logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -41,9 +93,10 @@ describe("validatePsychDS", () => {
       { severity: "error", key: "MISSING_FIELD", reason: "field is required" },
     ]));
     await validatePsychDS("/some/dataset", false);
-    expect(logSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 0 warnings.\n");
-    expect(logSpy).toHaveBeenCalledWith("  Error 1: MISSING_FIELD: field is required");
-    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 0 warnings.\n");
+    expect(errorSpy).toHaveBeenCalledWith("  Error 1: MISSING_FIELD: field is required");
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).not.toHaveBeenCalled();
   });
 
   test("prints only error lines when errors are present and verbose is true", async () => {
@@ -51,9 +104,10 @@ describe("validatePsychDS", () => {
       { severity: "error", key: "MISSING_FIELD", reason: "field is required" },
     ]));
     await validatePsychDS("/some/dataset", true);
-    expect(logSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 0 warnings.\n");
-    expect(logSpy).toHaveBeenCalledWith("  Error 1: MISSING_FIELD: field is required");
-    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 0 warnings.\n");
+    expect(errorSpy).toHaveBeenCalledWith("  Error 1: MISSING_FIELD: field is required");
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).not.toHaveBeenCalled();
   });
 
   test("prints rerun hint when warnings are present and verbose is false", async () => {
@@ -62,8 +116,9 @@ describe("validatePsychDS", () => {
     ]));
     await validatePsychDS("/some/dataset", false);
     expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (1 warning).");
-    expect(logSpy).toHaveBeenCalledWith("  (Rerun with --verbose to see warnings.)");
-    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith("  (Rerun with --verbose to see warnings.)");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   test("prints each warning when warnings are present and verbose is true", async () => {
@@ -72,9 +127,10 @@ describe("validatePsychDS", () => {
     ]));
     await validatePsychDS("/some/dataset", true);
     expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (1 warning).");
-    expect(logSpy).toHaveBeenCalledWith();  // blank separator line
-    expect(logSpy).toHaveBeenCalledWith("  Warning 1: OPTIONAL_MISSING: optional field absent");
-    expect(logSpy).toHaveBeenCalledTimes(3);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith();  // blank separator line
+    expect(warnSpy).toHaveBeenCalledWith("  Warning 1: OPTIONAL_MISSING: optional field absent");
+    expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 
   test("prints errors and warnings when both are present and verbose is true", async () => {
@@ -83,11 +139,13 @@ describe("validatePsychDS", () => {
       { severity: "warning", key: "OPTIONAL_MISSING", reason: "optional field absent" },
     ]));
     await validatePsychDS("/some/dataset", true);
-    expect(logSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 1 warning.\n");
-    expect(logSpy).toHaveBeenCalledWith("  Error 1: MISSING_FIELD: field is required");
-    expect(logSpy).toHaveBeenCalledWith();  // blank separator line
-    expect(logSpy).toHaveBeenCalledWith("  Warning 1: OPTIONAL_MISSING: optional field absent");
-    expect(logSpy).toHaveBeenCalledTimes(4);
+    expect(errorSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 1 warning.\n");
+    expect(errorSpy).toHaveBeenCalledWith("  Error 1: MISSING_FIELD: field is required");
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith();  // blank separator line
+    expect(warnSpy).toHaveBeenCalledWith("  Warning 1: OPTIONAL_MISSING: optional field absent");
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).not.toHaveBeenCalled();
   });
 
   test("uses correct plurals with multiple errors and 1 warning", async () => {
@@ -97,11 +155,13 @@ describe("validatePsychDS", () => {
       { severity: "warning", key: "WARN1", reason: "warn reason" },
     ]));
     await validatePsychDS("/some/dataset", false);
-    expect(logSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 2 errors, 1 warning.\n");
-    expect(logSpy).toHaveBeenCalledWith("  Error 1: ERR1: reason one");
-    expect(logSpy).toHaveBeenCalledWith("  Error 2: ERR2: reason two");
-    expect(logSpy).toHaveBeenCalledWith("  (Rerun with --verbose to see warnings.)");
-    expect(logSpy).toHaveBeenCalledTimes(4);
+    expect(errorSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 2 errors, 1 warning.\n");
+    expect(errorSpy).toHaveBeenCalledWith("  Error 1: ERR1: reason one");
+    expect(errorSpy).toHaveBeenCalledWith("  Error 2: ERR2: reason two");
+    expect(errorSpy).toHaveBeenCalledTimes(3);
+    expect(warnSpy).toHaveBeenCalledWith("  (Rerun with --verbose to see warnings.)");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).not.toHaveBeenCalled();
   });
 
   test("uses correct plural for multiple warnings", async () => {
@@ -111,26 +171,37 @@ describe("validatePsychDS", () => {
     ]));
     await validatePsychDS("/some/dataset", false);
     expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (2 warnings).");
-    expect(logSpy).toHaveBeenCalledWith("  (Rerun with --verbose to see warnings.)");
-    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith("  (Rerun with --verbose to see warnings.)");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   test("prints console.warn and returns without crashing when validate throws an Error", async () => {
     mockValidate.mockRejectedValue(new Error("validator failed"));
-    await expect(validatePsychDS("/some/dataset", false)).resolves.toBeUndefined();
+    await expect(validatePsychDS("/some/dataset", false)).resolves.toEqual({
+      hasErrors: false,
+      missingRequiredFields: [],
+      missingRecommendedFields: [],
+    });
     expect(warnSpy).toHaveBeenCalledWith(
       "\nWarning: Psych-DS validation could not run: validator failed"
     );
     expect(logSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
   test("prints the thrown value directly when validate throws a non-Error", async () => {
     mockValidate.mockRejectedValue("something went wrong");
-    await expect(validatePsychDS("/some/dataset", false)).resolves.toBeUndefined();
+    await expect(validatePsychDS("/some/dataset", false)).resolves.toEqual({
+      hasErrors: false,
+      missingRequiredFields: [],
+      missingRecommendedFields: [],
+    });
     expect(warnSpy).toHaveBeenCalledWith(
       "\nWarning: Psych-DS validation could not run: something went wrong"
     );
     expect(logSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/tests/validatefunctions.test.ts
+++ b/packages/cli/tests/validatefunctions.test.ts
@@ -31,6 +31,7 @@ describe("validatePsychDS", () => {
   test("prints ✔ line when validation passes with no warnings", async () => {
     mockValidate.mockResolvedValue(makeResult([]));
     await validatePsychDS("/some/dataset", false);
+    expect(mockValidate).toHaveBeenCalledWith(path.relative(process.cwd(), "/some/dataset"));
     expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (0 warnings).");
     expect(logSpy).toHaveBeenCalledTimes(1);
   });
@@ -59,7 +60,22 @@ describe("validatePsychDS", () => {
     ]));
     await validatePsychDS("/some/dataset", true);
     expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (1 warning).");
+    expect(logSpy).toHaveBeenCalledWith();  // blank separator line
     expect(logSpy).toHaveBeenCalledWith("  Warning 1: OPTIONAL_MISSING: optional field absent");
+    expect(logSpy).toHaveBeenCalledTimes(3);
+  });
+
+  test("prints errors and warnings when both are present and verbose is true", async () => {
+    mockValidate.mockResolvedValue(makeResult([
+      { severity: "error", key: "MISSING_FIELD", reason: "field is required" },
+      { severity: "warning", key: "OPTIONAL_MISSING", reason: "optional field absent" },
+    ]));
+    await validatePsychDS("/some/dataset", true);
+    expect(logSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 1 warning.\n");
+    expect(logSpy).toHaveBeenCalledWith("  Error 1: MISSING_FIELD: field is required");
+    expect(logSpy).toHaveBeenCalledWith();  // blank separator line
+    expect(logSpy).toHaveBeenCalledWith("  Warning 1: OPTIONAL_MISSING: optional field absent");
+    expect(logSpy).toHaveBeenCalledTimes(4);
   });
 
   test("uses correct plurals with multiple errors and warnings", async () => {

--- a/packages/cli/tests/validatefunctions.test.ts
+++ b/packages/cli/tests/validatefunctions.test.ts
@@ -86,6 +86,8 @@ describe("validatePsychDS", () => {
     expect(mockValidate).toHaveBeenCalledWith(path.relative(process.cwd(), "/some/dataset"));
     expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (0 warnings).");
     expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
     expect(result).toEqual({ hasErrors: false, missingRequiredFields: [], missingRecommendedFields: [] });
   });
 
@@ -120,11 +122,12 @@ describe("validatePsychDS", () => {
     mockValidate.mockResolvedValue(makeResult([
       { severity: "warning", key: "OPTIONAL_MISSING", reason: "optional field absent" },
     ]));
-    await validatePsychDS("/some/dataset", false);
+    const result = await validatePsychDS("/some/dataset", false);
     expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (1 warning).");
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith("  (Rerun with --verbose to see warnings.)");
     expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ hasErrors: false, missingRequiredFields: [], missingRecommendedFields: [] });
   });
 
   test("prints each warning when warnings are present and verbose is true", async () => {

--- a/packages/cli/tests/validatefunctions.test.ts
+++ b/packages/cli/tests/validatefunctions.test.ts
@@ -115,11 +115,20 @@ describe("validatePsychDS", () => {
     expect(logSpy).toHaveBeenCalledTimes(2);
   });
 
-  test("prints console.warn and returns without crashing when validate throws", async () => {
+  test("prints console.warn and returns without crashing when validate throws an Error", async () => {
     mockValidate.mockRejectedValue(new Error("validator failed"));
     await expect(validatePsychDS("/some/dataset", false)).resolves.toBeUndefined();
     expect(warnSpy).toHaveBeenCalledWith(
       "\nWarning: Psych-DS validation could not run: validator failed"
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  test("prints the thrown value directly when validate throws a non-Error", async () => {
+    mockValidate.mockRejectedValue("something went wrong");
+    await expect(validatePsychDS("/some/dataset", false)).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "\nWarning: Psych-DS validation could not run: something went wrong"
     );
     expect(logSpy).not.toHaveBeenCalled();
   });

--- a/packages/cli/tests/validatefunctions.test.ts
+++ b/packages/cli/tests/validatefunctions.test.ts
@@ -43,6 +43,17 @@ describe("validatePsychDS", () => {
     await validatePsychDS("/some/dataset", false);
     expect(logSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 0 warnings.\n");
     expect(logSpy).toHaveBeenCalledWith("  Error 1: MISSING_FIELD: field is required");
+    expect(logSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("prints only error lines when errors are present and verbose is true", async () => {
+    mockValidate.mockResolvedValue(makeResult([
+      { severity: "error", key: "MISSING_FIELD", reason: "field is required" },
+    ]));
+    await validatePsychDS("/some/dataset", true);
+    expect(logSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 1 error, 0 warnings.\n");
+    expect(logSpy).toHaveBeenCalledWith("  Error 1: MISSING_FIELD: field is required");
+    expect(logSpy).toHaveBeenCalledTimes(2);
   });
 
   test("prints rerun hint when warnings are present and verbose is false", async () => {
@@ -52,6 +63,7 @@ describe("validatePsychDS", () => {
     await validatePsychDS("/some/dataset", false);
     expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (1 warning).");
     expect(logSpy).toHaveBeenCalledWith("  (Rerun with --verbose to see warnings.)");
+    expect(logSpy).toHaveBeenCalledTimes(2);
   });
 
   test("prints each warning when warnings are present and verbose is true", async () => {
@@ -78,7 +90,7 @@ describe("validatePsychDS", () => {
     expect(logSpy).toHaveBeenCalledTimes(4);
   });
 
-  test("uses correct plurals with multiple errors and warnings", async () => {
+  test("uses correct plurals with multiple errors and 1 warning", async () => {
     mockValidate.mockResolvedValue(makeResult([
       { severity: "error", key: "ERR1", reason: "reason one" },
       { severity: "error", key: "ERR2", reason: "reason two" },
@@ -88,6 +100,19 @@ describe("validatePsychDS", () => {
     expect(logSpy).toHaveBeenCalledWith("\n✘ Psych-DS validation failed: 2 errors, 1 warning.\n");
     expect(logSpy).toHaveBeenCalledWith("  Error 1: ERR1: reason one");
     expect(logSpy).toHaveBeenCalledWith("  Error 2: ERR2: reason two");
+    expect(logSpy).toHaveBeenCalledWith("  (Rerun with --verbose to see warnings.)");
+    expect(logSpy).toHaveBeenCalledTimes(4);
+  });
+
+  test("uses correct plural for multiple warnings", async () => {
+    mockValidate.mockResolvedValue(makeResult([
+      { severity: "warning", key: "WARN1", reason: "warn one" },
+      { severity: "warning", key: "WARN2", reason: "warn two" },
+    ]));
+    await validatePsychDS("/some/dataset", false);
+    expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (2 warnings).");
+    expect(logSpy).toHaveBeenCalledWith("  (Rerun with --verbose to see warnings.)");
+    expect(logSpy).toHaveBeenCalledTimes(2);
   });
 
   test("prints console.warn and returns without crashing when validate throws", async () => {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "module": "Node16",
-    "moduleResolution": "node16",
+    "module": "CommonJS",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "types": ["jest", "node"]

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2018",
     "module": "CommonJS",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "types": ["jest", "node"]

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "module": "CommonJS",
+    "module": "Node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary

- Adds 10 unit tests for `validatePsychDS` in `packages/cli/tests/validatefunctions.test.ts`
- Mocks `psychds-validator` using `jest.doMock` + `jest.resetModules()` in `beforeEach` (required because `@sucrase/jest-plugin` does not hoist `jest.mock`)
- Adds `tsconfig.json` to the CLI package so VS Code resolves Jest globals correctly
- Covers all branches: clean pass, errors (verbose on/off), warnings (verbose on/off), mixed errors+warnings (verbose on/off), plural forms for both errors and warnings, Error throw, and non-Error throw

## Test plan

- [x] `npm test` in `packages/cli` — all 19 tests pass (10 new + 9 existing)
- [x] Each new test targets a distinct branch of `validatePsychDS`
- [x] All tests include `toHaveBeenCalledTimes` assertions to catch spurious extra output

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)