### PR TITLE
fix(cli): send validation errors and warnings to stderr

### DIFF
--- a/.changeset/cli-stderr-diagnostic-output.md
+++ b/.changeset/cli-stderr-diagnostic-output.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata-cli": patch
+---
+
+Send Psych-DS validation errors and warnings to stderr. The failure header and error details use console.error; warning details and the verbose hint use console.warn. The success line remains on stdout.

--- a/packages/cli/src/validatefunctions.ts
+++ b/packages/cli/src/validatefunctions.ts
@@ -28,7 +28,7 @@ export const validatePsychDS = async (datasetPath: string, verbose: boolean): Pr
   }
 
   if (verbose && warnings.length > 0) {
-    console.error();
+    console.warn();
     warnings.forEach((msg, i) => console.warn(`  Warning ${i + 1}: ${msg}`));
   } else if (!verbose && warnings.length > 0) {
     console.warn("  (Rerun with --verbose to see warnings.)");

--- a/packages/cli/src/validatefunctions.ts
+++ b/packages/cli/src/validatefunctions.ts
@@ -23,15 +23,15 @@ export const validatePsychDS = async (datasetPath: string, verbose: boolean): Pr
   if (errors.length === 0) {
     console.log(`\n✔ Psych-DS validation passed (${warnings.length} warning${warnings.length !== 1 ? 's' : ''}).`);
   } else {
-    console.log(`\n✘ Psych-DS validation failed: ${errors.length} error${errors.length !== 1 ? 's' : ''}, ${warnings.length} warning${warnings.length !== 1 ? 's' : ''}.\n`);
-    errors.forEach((msg, i) => console.log(`  Error ${i + 1}: ${msg}`));
+    console.error(`\n✘ Psych-DS validation failed: ${errors.length} error${errors.length !== 1 ? 's' : ''}, ${warnings.length} warning${warnings.length !== 1 ? 's' : ''}.\n`);
+    errors.forEach((msg, i) => console.error(`  Error ${i + 1}: ${msg}`));
   }
 
   if (verbose && warnings.length > 0) {
-    console.log();
-    warnings.forEach((msg, i) => console.log(`  Warning ${i + 1}: ${msg}`));
+    console.error();
+    warnings.forEach((msg, i) => console.warn(`  Warning ${i + 1}: ${msg}`));
   } else if (!verbose && warnings.length > 0) {
-    console.log("  (Rerun with --verbose to see warnings.)");
+    console.warn("  (Rerun with --verbose to see warnings.)");
   }
 };
 


### PR DESCRIPTION
## Summary

- `✘` failure header and individual error lines → `console.error` (stderr)
- Warning details (verbose) and the rerun hint → `console.warn` (stderr)
- `✔` success line stays on `console.log` (stdout) — it's the good-path result, not a diagnostic
- The blank separator line before verbose warnings → `console.error()` to match its block
- The throws-path `console.warn` was already correct

Separating diagnostic output onto stderr lets piped or scripted consumers distinguish clean data output from validation messages.

## Note on PR #61

PR #61's `validatePsychDS` tests currently assert the failure header and warning lines against `logSpy`. After this merges those assertions will need updating to `errorSpy`/`warnSpy` to match the new output channels.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)