### PR TITLE
test(cli): cover utils helpers and preAnalyzeDirectory

### DIFF
--- a/.changeset/cli-utils-data-tests.md
+++ b/.changeset/cli-utils-data-tests.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata-cli": patch
+---
+
+Add unit tests for the remaining untested CLI helpers: the pure functions in `utils.ts` (`sanitizePsychDSSegment`, `deriveArrayFilename`, `objectsToCSV`, `disambiguateArrayFilename`) and `preAnalyzeDirectory` in `data.ts` (29 tests).

--- a/packages/cli/tests/data.test.ts
+++ b/packages/cli/tests/data.test.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import JsPsychMetadata from "@jspsych/metadata";
-import { processOptions, loadMetadata, saveTextToPath, processDirectory } from "../src/data";
+import { processOptions, loadMetadata, saveTextToPath, processDirectory, preAnalyzeDirectory } from "../src/data";
 
 // Each describe block gets its own temp directory.
 let tmpDir: string;
@@ -145,5 +145,99 @@ describe("processDirectory", () => {
     // dataset_description.json is counted but loaded as metadata, not as a data failure
     expect(failed).toBe(0);
     expect(metadata.getMetadataField("name")).toBe("Existing");
+  });
+});
+
+describe("preAnalyzeDirectory", () => {
+  test("returns null for a directory that cannot be read", async () => {
+    const missing = path.join(tmpDir, "does-not-exist");
+    expect(await preAnalyzeDirectory(missing)).toBeNull();
+  });
+
+  test("returns null when every file is unique on the default join key", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "unique.json"),
+      JSON.stringify([{ trial_index: 0 }, { trial_index: 1 }, { trial_index: 2 }])
+    );
+    expect(await preAnalyzeDirectory(tmpDir)).toBeNull();
+  });
+
+  test("flags a file whose default join key is not unique", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "dupes.json"),
+      JSON.stringify([{ trial_index: 0 }, { trial_index: 0 }])
+    );
+
+    const result = await preAnalyzeDirectory(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.fileName).toBe("dupes.json");
+    expect(result!.analysis.isUnique).toBe(false);
+  });
+
+  test("parses CSV data files as well as JSON", async () => {
+    fs.writeFileSync(path.join(tmpDir, "dupes.csv"), "trial_index\n0\n0");
+
+    const result = await preAnalyzeDirectory(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.fileName).toBe("dupes.csv");
+    expect(result!.analysis.isUnique).toBe(false);
+  });
+
+  test("ignores dataset_description.json and unsupported file types", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "dataset_description.json"),
+      JSON.stringify([{ trial_index: 0 }, { trial_index: 0 }])
+    );
+    fs.writeFileSync(path.join(tmpDir, "notes.txt"), "trial_index\n0\n0");
+
+    expect(await preAnalyzeDirectory(tmpDir)).toBeNull();
+  });
+
+  test("returns the worst file (highest duplicate count) when several are non-unique", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "a.json"),
+      JSON.stringify([{ trial_index: 0 }, { trial_index: 0 }])
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "b.json"),
+      JSON.stringify([
+        { trial_index: 0 },
+        { trial_index: 0 },
+        { trial_index: 0 },
+        { trial_index: 0 },
+      ])
+    );
+
+    const result = await preAnalyzeDirectory(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.fileName).toBe("b.json");
+  });
+
+  test("inspects data files one subdirectory deep", async () => {
+    const subDir = path.join(tmpDir, "sub");
+    fs.mkdirSync(subDir);
+    fs.writeFileSync(
+      path.join(subDir, "dupes.json"),
+      JSON.stringify([{ trial_index: 0 }, { trial_index: 0 }])
+    );
+
+    const result = await preAnalyzeDirectory(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.fileName).toBe("dupes.json");
+  });
+
+  test("honors a custom set of initial join keys", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "data.json"),
+      JSON.stringify([
+        { trial_index: 0, subject: "s1" },
+        { trial_index: 0, subject: "s2" },
+      ])
+    );
+
+    // Unique on [subject] even though trial_index repeats.
+    expect(await preAnalyzeDirectory(tmpDir, ["subject"])).toBeNull();
+    // Not unique on the default [trial_index].
+    expect(await preAnalyzeDirectory(tmpDir, ["trial_index"])).not.toBeNull();
   });
 });

--- a/packages/cli/tests/utils.test.ts
+++ b/packages/cli/tests/utils.test.ts
@@ -1,6 +1,12 @@
 import os from "os";
 import path from "path";
-import { expandHomeDir } from "../src/utils";
+import {
+  expandHomeDir,
+  sanitizePsychDSSegment,
+  deriveArrayFilename,
+  objectsToCSV,
+  disambiguateArrayFilename,
+} from "../src/utils";
 import { generatePath } from "../src/data";
 
 describe("expandHomeDir", () => {
@@ -31,5 +37,132 @@ describe("generatePath", () => {
   test("resolves a relative path against the current working directory", () => {
     const relative = "relative/path";
     expect(generatePath(relative)).toBe(path.resolve(process.cwd(), relative));
+  });
+});
+
+describe("sanitizePsychDSSegment", () => {
+  test("lowercases the input", () => {
+    expect(sanitizePsychDSSegment("ResponseKey")).toBe("responsekey");
+  });
+
+  test("replaces spaces, underscores, and periods with hyphens", () => {
+    expect(sanitizePsychDSSegment("mouse tracking")).toBe("mouse-tracking");
+    expect(sanitizePsychDSSegment("mouse_tracking")).toBe("mouse-tracking");
+    expect(sanitizePsychDSSegment("validation.pointData")).toBe("validation-pointdata");
+  });
+
+  test("collapses runs of replacement characters into a single hyphen", () => {
+    expect(sanitizePsychDSSegment("a   b")).toBe("a-b");
+    expect(sanitizePsychDSSegment("a___b")).toBe("a-b");
+  });
+
+  test("trims leading and trailing hyphens", () => {
+    expect(sanitizePsychDSSegment("_leading")).toBe("leading");
+    expect(sanitizePsychDSSegment("trailing_")).toBe("trailing");
+    expect(sanitizePsychDSSegment("__both__")).toBe("both");
+  });
+
+  test("leaves already-safe alphanumeric-hyphen values unchanged", () => {
+    expect(sanitizePsychDSSegment("participant-001")).toBe("participant-001");
+  });
+});
+
+describe("deriveArrayFilename", () => {
+  test("strips the extension and trailing _data, then sanitizes both segments", () => {
+    // NB: sanitizePsychDSSegment converts the underscore in the stem to a hyphen, so the
+    // two keyword-value pairs in the source name collapse into one segment. This diverges
+    // from the function's JSDoc example (which shows the underscore preserved) — see issue #8
+    // follow-up. This assertion captures the actual current behavior.
+    expect(deriveArrayFilename("participant-001_session-1_data.csv", "mouse_tracking_data")).toBe(
+      "participant-001-session-1_measure-mouse-tracking-data_data.csv"
+    );
+  });
+
+  test("sanitizes a source filename with spaces and mixed case", () => {
+    expect(deriveArrayFilename("Keyboard Response.csv", "response")).toBe(
+      "keyboard-response_measure-response_data.csv"
+    );
+  });
+
+  test("sanitizes a dotted column name", () => {
+    expect(deriveArrayFilename("stem.csv", "validation_data.pointData")).toBe(
+      "stem_measure-validation-data-pointdata_data.csv"
+    );
+  });
+
+  test("strips _data case-insensitively", () => {
+    expect(deriveArrayFilename("trial_DATA.json", "col")).toBe("trial_measure-col_data.csv");
+  });
+});
+
+describe("objectsToCSV", () => {
+  test("returns an empty string for no rows", () => {
+    expect(objectsToCSV([])).toBe("");
+  });
+
+  test("places priority columns first, then remaining columns in first-seen order", () => {
+    const rows = [{ rt: 450, trial_index: 0, stimulus: "a" }];
+    expect(objectsToCSV(rows)).toBe("trial_index,rt,stimulus\r\n0,450,a");
+  });
+
+  test("omits priority columns that are not present in the data", () => {
+    const rows = [{ rt: 450 }];
+    expect(objectsToCSV(rows)).toBe("rt\r\n450");
+  });
+
+  test("unions columns across rows and leaves missing values blank", () => {
+    const rows = [{ a: 1 }, { a: 2, b: 3 }];
+    expect(objectsToCSV(rows)).toBe("a,b\r\n1,\r\n2,3");
+  });
+
+  test("renders null and undefined as empty cells", () => {
+    const rows = [{ a: null, b: undefined, c: 0 }];
+    expect(objectsToCSV(rows)).toBe("a,b,c\r\n,,0");
+  });
+
+  test("quotes and escapes values containing commas, quotes, or newlines (RFC 4180)", () => {
+    const rows = [{ a: "x,y", b: 'he said "hi"', c: "line1\nline2" }];
+    expect(objectsToCSV(rows)).toBe('a,b,c\r\n"x,y","he said ""hi""","line1\nline2"');
+  });
+
+  test("separates rows with CRLF", () => {
+    const rows = [{ a: 1 }, { a: 2 }];
+    expect(objectsToCSV(rows).split("\r\n")).toEqual(["a", "1", "2"]);
+  });
+
+  test("honors a custom priority column list", () => {
+    const rows = [{ a: 1, z: 2 }];
+    expect(objectsToCSV(rows, ["z"])).toBe("z,a\r\n2,1");
+  });
+});
+
+describe("disambiguateArrayFilename", () => {
+  test("returns the base name unchanged when it is not already used", () => {
+    expect(disambiguateArrayFilename("foo_measure-bar_data.csv", new Set())).toBe(
+      "foo_measure-bar_data.csv"
+    );
+  });
+
+  test("inserts a numeric suffix before _data.csv when the base collides", () => {
+    const used = new Set(["foo_measure-bar_data.csv"]);
+    expect(disambiguateArrayFilename("foo_measure-bar_data.csv", used)).toBe(
+      "foo_measure-bar-2_data.csv"
+    );
+  });
+
+  test("increments the suffix until a free name is found", () => {
+    const used = new Set([
+      "foo_measure-bar_data.csv",
+      "foo_measure-bar-2_data.csv",
+      "foo_measure-bar-3_data.csv",
+    ]);
+    expect(disambiguateArrayFilename("foo_measure-bar_data.csv", used)).toBe(
+      "foo_measure-bar-4_data.csv"
+    );
+  });
+
+  test("falls back to stripping a plain .csv extension when there is no _data.csv suffix", () => {
+    const used = new Set(["plain.csv"]);
+    expect(disambiguateArrayFilename("plain.csv", used)).toBe("plain-2_data.csv");
   });
 });


### PR DESCRIPTION
## Summary

Closes the remaining gaps in the CLI test suite (#8). Adds unit tests for the previously-untested **pure helpers in `utils.ts`** and **`preAnalyzeDirectory` in `data.ts`** — the functions identified as having no coverage.

Test-only change: no source files are modified, so there's no behavioral risk.

## Coverage added (29 tests)

**`utils.ts`**
- `sanitizePsychDSSegment` — lowercasing, separator → hyphen replacement, run-collapsing, edge trimming
- `deriveArrayFilename` — extension/`_data` stripping and segment sanitization
- `objectsToCSV` — priority-column ordering, column unioning, blank/`null`/`undefined` cells, RFC 4180 quoting/escaping, CRLF line endings, custom priority lists
- `disambiguateArrayFilename` — pass-through, numeric-suffix insertion, increment-until-free, plain-`.csv` fallback

**`data.ts`**
- `preAnalyzeDirectory` — unreadable dir → `null`, all-unique → `null`, JSON and CSV duplicate detection, ignoring `dataset_description.json` / unsupported types, worst-file selection, one-subdirectory-deep traversal, custom join keys

## ⚠️ Behavior flagged by the tests

`deriveArrayFilename`'s JSDoc example shows `participant-001_session-1_data.csv` → `participant-001_session-1_measure-..._data.csv`, but the code actually produces `participant-001-session-1_measure-...` — `sanitizePsychDSSegment` rewrites the underscore in the stem to a hyphen, collapsing two Psych-DS `keyword-value` pairs into one. The test captures the **actual** behavior with an inline note. This may warrant a follow-up fix (the doc and code disagree, and it can break the Psych-DS filename structure for multi-segment source names).

## Test run

61/61 CLI tests pass (was 32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)