### PR TITLE
fix(metadata): strip JSDoc continuation asterisks in plugin descriptions

### DIFF
--- a/.changeset/webgazer-description-parsing.md
+++ b/.changeset/webgazer-description-parsing.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata": patch
+---
+
+Strip JSDoc continuation `*` markers when parsing multi-line plugin/extension variable descriptions, so descriptions like the webgazer extension's `webgazer_data` no longer contain stray asterisks. Adds a regression test for webgazer-shaped multi-line JSDoc.

--- a/packages/metadata/src/PluginCache.ts
+++ b/packages/metadata/src/PluginCache.ts
@@ -191,7 +191,13 @@ export class PluginCache {
 
     let match;
     while ((match = varStartRegex.exec(block)) !== null) {
-      const description = match[1].trim().replace(/\s+/g, " ");
+      // Strip the leading "*" that JSDoc puts at the start of each continuation line
+      // before collapsing whitespace, otherwise multi-line descriptions keep stray
+      // asterisks (e.g. "The `x` and * `y` properties ...").
+      const description = match[1]
+        .replace(/^[ \t]*\*[ \t]?/gm, "")
+        .trim()
+        .replace(/\s+/g, " ");
       const varName = match[2];
 
       const braceStart = match.index + match[0].length - 1;

--- a/packages/metadata/tests/plugin-cache.test.ts
+++ b/packages/metadata/tests/plugin-cache.test.ts
@@ -49,6 +49,24 @@ const info = <const>{
 };
 `;
 
+// Extension source shaped like @jspsych/extension-webgazer: an extension (not a plugin)
+// whose data descriptions span multiple JSDoc lines with leading "*" continuation markers.
+const WEBGAZER_EXTENSION_SOURCE = `
+const info = <const>{
+  name: "webgazer",
+  parameters: {},
+  data: {
+    /** An array of objects containing gaze data for the trial. Each object has an \`x\`, a \`y\`, and a \`t\` property. The \`x\` and
+     * \`y\` properties specify the gaze location in pixels and \`t\` specifies the time in milliseconds since the start of the trial. */
+    webgazer_data: {
+      type: ParameterType.INT,
+      array: true,
+    },
+  },
+  citations: '__CITATIONS__',
+};
+`;
+
 function makeFetch(source: string, status = 200) {
   return jest.fn().mockResolvedValue({
     ok: status >= 200 && status < 300,
@@ -119,6 +137,25 @@ describe("PluginCache parsing fixes", () => {
     expect(viewingTime).toBeDefined();
     expect(viewingTime.description).not.toBe("unknown");
     expect(viewingTime.description).toMatch(/viewing the page/i);
+  });
+
+  test("webgazer-shaped source: multi-line JSDoc description is extracted without stray asterisks", async () => {
+    // fetch is mocked, so the plugin-vs-extension URL is irrelevant here; what this guards
+    // is that a webgazer-style multi-line JSDoc block parses cleanly (issue #19).
+    (global as any).fetch = makeFetch(WEBGAZER_EXTENSION_SOURCE);
+    const meta = new JsPsychMetadata();
+    await meta.generate(
+      JSON.stringify([{ trial_type: "webgazer", trial_index: 0, time_elapsed: 100, webgazer_data: [] }])
+    );
+
+    const variableMeasured = meta.getMetadata()["variableMeasured"] as any[];
+    const v = variableMeasured.find((e) => e.name === "webgazer_data");
+    expect(v).toBeDefined();
+    expect(v.description).not.toBe("unknown");
+    expect(v.description).toMatch(/array of objects containing gaze data/i);
+    // The continuation-line "*" must not survive into the joined description.
+    expect(v.description).not.toMatch(/\*/);
+    expect(v.description).toMatch(/the `x` and `y` properties/i);
   });
 
   test("non-ok HTTP response: falls back to unknown description without throwing", async () => {


### PR DESCRIPTION
## Summary

Closes #19. Investigation showed the original "Webgazer unpkg fetching error" is **already resolved** — `https://unpkg.com/@jspsych/extension-webgazer/src/index.ts` returns HTTP 200 and the current parser extracts both `webgazer_data` and `webgazer_targets` successfully (fixed by the PluginCache rewrite in #50).

The one remaining artifact: **multi-line JSDoc descriptions kept the leading `*`** that JSDoc places at the start of each continuation line. For webgazer's `webgazer_data` this produced:

> "An array of objects containing gaze data ... The `x` and **\*** `y` properties specify ..."

This PR strips those continuation markers before collapsing whitespace.

## Change

`extractJsdocFields` in `PluginCache.ts`:
```diff
-const description = match[1].trim().replace(/\s+/g, " ");
+const description = match[1]
+  .replace(/^[ \t]*\*[ \t]?/gm, "")
+  .trim()
+  .replace(/\s+/g, " ");
```

Single-line descriptions are unaffected (no leading `*` to strip).

## Tests

Adds a webgazer-shaped multi-line JSDoc regression test asserting the description is extracted and contains no stray `*`. Full metadata suite: **65/65 pass**.

## Note on #16

The broader "replace the custom JSDoc parser with a maintained package" work is **#16**, left open as lower-priority tech debt — the hand-rolled parser was recently hardened in #50 and works. This PR is the targeted #19 fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)