### PR TITLE
docs: getting-started tutorial and CLI README rewrite

### DIFF
--- a/.changeset/docs-getting-started.md
+++ b/.changeset/docs-getting-started.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata-cli": patch
+---
+
+Rewrite CLI README with full interactive flow and flag reference.

--- a/.changeset/docs-getting-started.md
+++ b/.changeset/docs-getting-started.md
@@ -1,5 +1,0 @@
----
-"@jspsych/metadata-cli": patch
----
-
-Rewrite CLI README with full interactive flow and flag reference.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,152 @@
+# CLI Reference
+
+This page documents all flags, exit codes, filename rules, and output behaviour for the jsPsych Metadata CLI. For a step-by-step walkthrough of a typical first run, see [Getting Started](getting-started.md).
+
+---
+
+## Running the tool
+
+```
+npx @jspsych/metadata-cli [flags]
+```
+
+With no flags, the tool runs interactively and prompts you for everything it needs. All flags are optional — any flag you omit will be filled in by a prompt at runtime.
+
+---
+
+## Flags
+
+| Flag | Alias | Type | Description |
+|------|-------|------|-------------|
+| `--psych-ds-dir` | `-em` | path | Path to an **existing** Psych-DS project folder. Must contain a `dataset_description.json`. Use this when updating a project you have already generated. |
+| `--data-dir` | `-d` | path | Path to the folder containing your raw jsPsych data files (`.csv` or `.json`). |
+| `--metadata-options` | `-m` | path | Path to a metadata options `.json` file. See [Metadata Options](metadata-options.md). |
+| `--verbose` | `-v` | boolean | Print detailed output at each processing step. Shows plugin fetching, variable resolution, and full validation warnings. |
+
+### Notes on flag behaviour
+
+- Paths can use `~` for your home directory (e.g. `--data-dir=~/experiments/raw`).
+- If a flag is provided but the path is invalid, the tool falls back to prompting for that step interactively.
+- `--psych-ds-dir` implies **update mode** — the tool loads the existing `dataset_description.json` before processing new data. Without this flag, the tool asks whether to create or update.
+
+---
+
+## Non-interactive mode
+
+When all three path flags are provided and valid, every interactive prompt is skipped and the tool runs to completion without user input:
+
+```
+npx @jspsych/metadata-cli \
+  --psych-ds-dir=/path/to/project \
+  --data-dir=/path/to/data \
+  --metadata-options=/path/to/options.json
+```
+
+Non-interactive mode enforces stricter rules than interactive mode:
+
+- **Non-compliant filenames are a hard error.** In interactive mode, the tool prompts you to choose a keyword to bring non-compliant filenames into the Psych-DS naming pattern. In non-interactive mode, a non-compliant filename causes the tool to exit immediately with an error message and exit code 1. Rename your files before running (see [Data file naming](#data-file-naming) below).
+- **Unknown variable descriptions are not prompted.** Variables the tool cannot automatically describe are left as `"unknown"` in the output.
+
+Non-interactive mode is useful for running the tool on a schedule, in a script, or on a remote machine.
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Completed successfully. Psych-DS validation passed (warnings are allowed). |
+| `1` | Psych-DS validation failed with one or more errors, or a non-compliant filename was found in non-interactive mode. |
+
+You can use the exit code in a shell script to handle failures:
+
+```bash
+npx @jspsych/metadata-cli --psych-ds-dir=./project --data-dir=./data --metadata-options=./options.json
+if [ $? -ne 0 ]; then
+  echo "Metadata generation failed — check the output above for errors."
+fi
+```
+
+---
+
+## Data file requirements
+
+### Accepted formats
+
+The tool accepts `.csv` and `.json` data files produced by jsPsych. JSON files are automatically converted to CSV in the output (`data/` folder); the originals are preserved byte-for-byte in `data/raw/`. CSV files are copied to `data/` under their normalized name; originals are also preserved in `data/raw/`.
+
+Files of any other type are ignored during metadata generation.
+
+### Folder depth
+
+The tool reads all files in the data folder and one level of subdirectories. Files nested deeper are not processed.
+
+### Data file naming
+
+Psych-DS requires all data files to follow a `keyword-value_data.csv` naming pattern. Each filename consists of one or more `keyword-value` pairs joined by underscores, ending with `_data.csv`.
+
+**Valid examples:**
+
+```
+subject-01_data.csv
+task-flanker_data.csv
+subject-01_session-2_data.csv
+study-zebraQuestionnaire_data.csv
+```
+
+**Invalid examples:**
+
+```
+results.csv                   ← missing keyword-value structure and _data suffix
+participant_01.csv            ← underscore instead of hyphen between keyword and value
+data_2024-01-15.csv           ← date is not in keyword-value format
+flanker_results_data.csv      ← "flanker_results" is not a keyword-value pair
+```
+
+In **interactive mode**, the tool detects non-compliant names and prompts you to choose a keyword. The file's current name becomes the value (with hyphens and underscores removed, since Psych-DS values may not contain them). For example:
+
+```
+participant_01.csv → subject-participant01_data.csv
+flanker_results.json → task-flankerResults_data.csv
+```
+
+Official Psych-DS keywords offered by the tool:
+
+| Keyword | Intended use |
+|---------|-------------|
+| `subject` | The participant or subject the data belongs to |
+| `session` | A session of data collection |
+| `task` | The task in which the data was collected |
+| `condition` | The experimental condition |
+| `trial` | The trial the data belongs to |
+| `stimulus` | The stimulus item |
+| `study` | The study the data belongs to |
+| `site` | The site where data was collected |
+| `description` | A free-form label |
+
+Custom keywords are allowed but will produce a validator warning. In **non-interactive mode**, non-compliant filenames are a hard error — rename files before running.
+
+---
+
+## Validation output
+
+After generating `dataset_description.json`, the tool automatically validates the project against the Psych-DS specification.
+
+**Passed:**
+```
+✔ Psych-DS validation passed (2 warnings).
+  (Rerun with --verbose to see warnings.)
+```
+
+**Failed:**
+```
+✘ Psych-DS validation failed: 1 error, 0 warnings.
+
+  Error 1: JSON_KEY_REQUIRED: dataset_description.json is missing required field(s): [description]
+```
+
+Warnings are advisory — they indicate recommended fields or practices that aren't strictly required. A dataset with warnings is still valid. Errors must be resolved for the dataset to be Psych-DS compliant.
+
+Run with `--verbose` to see the full list of warnings alongside errors.
+
+If validation fails due to missing required fields and you are running interactively, the tool will prompt you to fill them in before finishing.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,211 @@
+# Getting Started: Organizing jsPsych Data with the Metadata CLI
+
+This guide walks you through using the jsPsych Metadata CLI to turn your raw experiment data into a [Psych-DS](https://psych-ds.github.io/) compliant dataset. By the end, you'll have a structured project folder with a `dataset_description.json` file that describes your experiment and its variables.
+
+## What is Psych-DS?
+
+[Psych-DS](https://psych-ds.github.io/) is a community standard for organizing and documenting psychology datasets. A Psych-DS compliant dataset has a predictable folder structure and a machine-readable description file. This makes your data easier to share, archive, and reuse — by collaborators, reviewers, or your future self.
+
+The Metadata CLI automates the most tedious part: generating the `dataset_description.json` by reading your jsPsych data files and looking up what each variable means.
+
+## Before you start
+
+You'll need:
+
+- **Node.js** installed on your computer (version 18 or later). You can check by running `node --version` in your terminal. If it's not installed, download it from [nodejs.org](https://nodejs.org).
+- **Your jsPsych data files** — CSV or JSON files produced by your experiment. These can be in one folder or organized into subfolders one level deep.
+
+## Running the tool
+
+Open a terminal and run:
+
+```
+npx @jspsych/metadata-cli
+```
+
+The first time you run this, `npx` will download the tool automatically. After that it launches immediately.
+
+---
+
+## Interactive walkthrough
+
+This section follows a researcher named Alex who collected data from a flanker task. Alex has two data files, `participant_01.csv` and `participant_02.csv`, saved in `~/experiments/flanker-raw/`.
+
+### Step 1: Create a new project or update an existing one
+
+```
+? What would you like to do?
+❯ Create a new project
+  Update an existing project
+```
+
+Select **Create a new project** if this is the first time you're generating metadata for this dataset. Use **Update an existing project** if you've run the tool before and want to regenerate the metadata (for example, after collecting more data).
+
+Alex selects **Create a new project**.
+
+---
+
+### Step 2: Choose where to save the project
+
+```
+? Path to the folder where the new project will be created: ~/experiments
+```
+
+This is the folder that will *contain* your new project. The tool will create a new subfolder inside it.
+
+Alex enters `~/experiments`.
+
+---
+
+### Step 3: Name your project
+
+```
+? Enter the project name (used as the folder name and in the metadata): flanker-study
+```
+
+The name becomes the subfolder name and is recorded in the metadata. Use something descriptive without spaces.
+
+---
+
+### Step 4: Point to your data
+
+```
+? Path to your raw data folder (files will be copied, not moved): ~/experiments/flanker-raw
+```
+
+Your original files are never modified. The tool copies them into the new project.
+
+---
+
+### Step 5: File naming (if your files need renaming)
+
+Psych-DS requires data files to follow a specific naming pattern: `keyword-value_data.csv`. For example, `subject-01_data.csv` or `task-flanker_data.csv`.
+
+If your files don't already follow this pattern, the tool will tell you and ask how to label them:
+
+```
+2 data file(s) do not follow the Psych-DS naming pattern ([keyword-value_]+data.csv):
+    participant_01.csv
+    participant_02.csv
+
+? Choose a Psych-DS keyword to label these files (their current name becomes the value):
+❯ subject   - The participant/subject the data belongs to
+  session   - A session of data collection
+  task      - The task in which the data was collected
+  condition - The experimental condition
+  trial     - The trial the data belongs to
+  stimulus  - The stimulus item
+  study     - The study the data belongs to
+  site      - The site where the data was collected
+  description - A free-form label describing the file
+  ──────────────
+  Other (custom keyword)
+```
+
+Choose the keyword that best describes what your filename refers to. Alex's files are named by participant, so she selects **subject**:
+
+```
+    participant_01.csv → subject-participant01_data.csv
+    participant_02.csv → subject-participant02_data.csv
+```
+
+The part after the hyphen is your original filename (with hyphens and underscores removed, since Psych-DS values don't allow them).
+
+> **If you prefer, rename your files before running the tool.** A compliant name looks like `subject-01_data.csv` — a keyword, a hyphen, a value, then `_data.csv`. Files that already follow this pattern are used as-is, with no prompt.
+
+---
+
+### Step 6: Customize metadata (optional)
+
+```
+? Would you like to customize the metadata?
+❯ Use defaults
+  Use a custom metadata file
+```
+
+The tool generates metadata automatically from your data files. If you want to add author names, a study description, or override variable descriptions, choose **Use a custom metadata file** and provide a path to a `.json` file. See [metadata-options.md](metadata-options.md) for the format.
+
+For now, Alex selects **Use defaults**. She can always edit `dataset_description.json` directly later.
+
+---
+
+### Step 7: Fill in unknown variable descriptions (optional)
+
+After reading your data files, the tool tries to look up what each variable means by checking the jsPsych plugin that produced it. For variables it couldn't identify automatically, it will ask:
+
+```
+3 variable(s) have unknown descriptions. Would you like to fill them in?
+❯ Fill in descriptions   - You will be prompted for each variable. Press Enter to skip individual ones.
+  Skip                   - Leave descriptions as unknown in the dataset_description.json.
+```
+
+If you choose to fill them in, you'll see one prompt per variable. Press Enter to skip any you'd rather leave for later.
+
+---
+
+### Step 8: Validation
+
+The tool automatically checks your new project against the Psych-DS specification:
+
+```
+✔ Psych-DS validation passed (2 warnings).
+  (Rerun with --verbose to see warnings.)
+```
+
+A checkmark means your dataset is valid. Warnings are minor issues (like recommended fields that aren't filled in yet) — your dataset is still usable. If there are errors, the tool will describe them and may prompt you to fix required fields before finishing.
+
+---
+
+## What you get
+
+After running the tool, Alex's new project is at `~/experiments/flanker-study/`:
+
+```
+flanker-study/
+├── data/
+│   ├── raw/
+│   │   ├── participant_01.csv        original files, untouched
+│   │   └── participant_02.csv
+│   ├── subject-participant01_data.csv   Psych-DS normalized copies
+│   └── subject-participant02_data.csv
+├── dataset_description.json             generated metadata
+├── README.md                            placeholder for a human-readable description
+└── CHANGES.md                           placeholder for a changelog
+```
+
+The `data/raw/` folder holds your original files exactly as they were. The `data/` folder holds the Psych-DS-compliant copies (JSON files are converted to CSV so the validator can read them).
+
+Open `dataset_description.json` to see what was generated. It will look something like:
+
+```json
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "name": "flanker-study",
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "name": "trial_type",
+      "description": "The name of the jsPsych plugin used to run the trial."
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "rt",
+      "description": {
+        "jsPsych-html-keyboard-response": "The response time in milliseconds..."
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Next steps
+
+- **Edit `dataset_description.json`** to add your name as an author, a study description, or other dataset-level fields.
+- **Edit `README.md`** inside your project to add a human-readable description of the experiment.
+- **Re-run the CLI** any time you add new data: use **Update an existing project** and point to your project folder — it will reload your existing metadata and incorporate the new files.
+- **Share or archive your project folder** — it's a self-contained, Psych-DS compliant dataset.
+
+For automating the tool in scripts, see [cli-reference.md](cli-reference.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,9 @@ This guide walks you through using the jsPsych Metadata CLI to turn your raw exp
 
 ## What is Psych-DS?
 
-[Psych-DS](https://psych-ds.github.io/) is a community standard for organizing and documenting psychology datasets. A Psych-DS compliant dataset has a predictable folder structure and a machine-readable description file. This makes your data easier to share, archive, and reuse — by collaborators, reviewers, or your future self.
+[Psych-DS](https://psych-ds.github.io/) is a community standard for organizing and documenting psychology datasets. A Psych-DS compliant dataset has a predictable folder structure and a machine-readable description file (`dataset_description.json`) that travels with the data, making it easier to share, archive, and reuse — by collaborators, reviewers, or your future self.
+
+If you'd like more background before diving in, see [What is Psych-DS?](what-is-psych-ds.md).
 
 The Metadata CLI automates the most tedious part: generating the `dataset_description.json` by reading your jsPsych data files and looking up what each variable means.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ The first time you run this, `npx` will download the tool automatically. After t
 
 ## Interactive walkthrough
 
-This section follows a researcher named Alex who collected data from a flanker task. Alex has two data files, `participant_01.csv` and `participant_02.csv`, saved in `~/experiments/flanker-raw/`.
+The following steps use two example data files named `participant_01.csv` and `participant_02.csv`.
 
 ### Step 1: Create a new project or update an existing one
 
@@ -43,19 +43,20 @@ This section follows a researcher named Alex who collected data from a flanker t
 
 Select **Create a new project** if this is the first time you're generating metadata for this dataset. Use **Update an existing project** if you've run the tool before and want to regenerate the metadata (for example, after collecting more data).
 
-Alex selects **Create a new project**.
-
 ---
 
 ### Step 2: Choose where to save the project
 
 ```
-? Path to the folder where the new project will be created: ~/experiments
+? Path to the folder where the new project will be created:
 ```
 
-This is the folder that will *contain* your new project. The tool will create a new subfolder inside it.
+Enter the path to an existing folder — the tool will create a new subfolder inside it for your project. **The folder you enter here must already exist.**
 
-Alex enters `~/experiments`.
+- **Windows:** `C:\Users\yourname\Documents\experiments`
+- **Mac / Linux:** `/Users/yourname/Documents/experiments` or `~/experiments`
+
+On Windows, you can copy the path directly from File Explorer's address bar. On Mac, you can drag a folder into the terminal window to paste its path. The `~` character is a shortcut for your home folder on Mac and Linux.
 
 ---
 
@@ -65,17 +66,17 @@ Alex enters `~/experiments`.
 ? Enter the project name (used as the folder name and in the metadata): flanker-study
 ```
 
-The name becomes the subfolder name and is recorded in the metadata. Use something descriptive without spaces.
+The name becomes the subfolder created inside the folder from Step 2, and is recorded in the metadata. Use something descriptive without spaces (hyphens are fine).
 
 ---
 
 ### Step 4: Point to your data
 
 ```
-? Path to your raw data folder (files will be copied, not moved): ~/experiments/flanker-raw
+? Path to your raw data folder (files will be copied, not moved):
 ```
 
-Your original files are never modified. The tool copies them into the new project.
+Enter the path to the folder containing your jsPsych data files. Use the same path format as Step 2 — the full path to an existing folder on your computer. Your original files are never modified; the tool copies them into the new project.
 
 ---
 
@@ -104,14 +105,14 @@ If your files don't already follow this pattern, the tool will tell you and ask 
   Other (custom keyword)
 ```
 
-Choose the keyword that best describes what your filename refers to. Alex's files are named by participant, so she selects **subject**:
+Choose the keyword that best describes what your filenames refer to. Since these files are named by participant, select **subject**:
 
 ```
     participant_01.csv → subject-participant01_data.csv
     participant_02.csv → subject-participant02_data.csv
 ```
 
-The part after the hyphen is your original filename (with hyphens and underscores removed, since Psych-DS values don't allow them).
+The part after the hyphen is your original filename with hyphens and underscores removed (Psych-DS values don't allow them).
 
 > **If you prefer, rename your files before running the tool.** A compliant name looks like `subject-01_data.csv` — a keyword, a hyphen, a value, then `_data.csv`. Files that already follow this pattern are used as-is, with no prompt.
 
@@ -125,9 +126,9 @@ The part after the hyphen is your original filename (with hyphens and underscore
   Use a custom metadata file
 ```
 
-The tool generates metadata automatically from your data files. If you want to add author names, a study description, or override variable descriptions, choose **Use a custom metadata file** and provide a path to a `.json` file. See [metadata-options.md](metadata-options.md) for the format.
+The tool generates metadata automatically from your data files. If you want to add author names, a study description, or override variable descriptions, choose **Use a custom metadata file** and provide a path to a `.json` file. See [Metadata Options](metadata-options.md) for the format.
 
-For now, Alex selects **Use defaults**. She can always edit `dataset_description.json` directly later.
+Select **Use defaults** for now — you can always edit `dataset_description.json` directly later, or re-run the CLI and provide an options file at that point.
 
 ---
 
@@ -160,7 +161,7 @@ A checkmark means your dataset is valid. Warnings are minor issues (like recomme
 
 ## What you get
 
-After running the tool, Alex's new project is at `~/experiments/flanker-study/`:
+Your new project folder will be inside the location you chose in Step 2, named after the project name from Step 3. For example, if you chose `C:\Users\yourname\Documents\experiments` as the output location and `flanker-study` as the project name, the result is at `C:\Users\yourname\Documents\experiments\flanker-study\`:
 
 ```
 flanker-study/
@@ -210,4 +211,4 @@ Open `dataset_description.json` to see what was generated. It will look somethin
 - **Re-run the CLI** any time you add new data: use **Update an existing project** and point to your project folder — it will reload your existing metadata and incorporate the new files.
 - **Share or archive your project folder** — it's a self-contained, Psych-DS compliant dataset.
 
-For automating the tool in scripts, see [cli-reference.md](cli-reference.md).
+For automating the tool in scripts, see [CLI Reference](cli-reference.md).

--- a/docs/metadata-options.md
+++ b/docs/metadata-options.md
@@ -1,0 +1,158 @@
+# Metadata Options File
+
+A metadata options file lets you set or override fields in the generated `dataset_description.json` before it is saved. You can use it to add author information, a dataset description, or custom variable descriptions that the tool couldn't determine automatically.
+
+Pass the file path to the CLI with the `--metadata-options` flag, or choose **Use a custom metadata file** when prompted interactively.
+
+---
+
+## File format
+
+The options file is a plain JSON file. It can have any name and be stored anywhere — only the content matters.
+
+At the top level, each key maps to a field in `dataset_description.json`. Two keys have special handling (`author` and `variables`); everything else is written through directly.
+
+**Minimal example:**
+
+```json
+{
+  "name": "Flanker Study",
+  "description": "A jsPsych flanker task measuring response inhibition."
+}
+```
+
+**Complete example:**
+
+```json
+{
+  "name": "Flanker Study",
+  "description": "A jsPsych flanker task measuring response inhibition in undergraduate participants.",
+  "author": {
+    "Alex Johnson": {
+      "givenName": "Alex",
+      "familyName": "Johnson",
+      "identifier": "https://orcid.org/0000-0000-0000-0000"
+    }
+  },
+  "variables": {
+    "rt": {
+      "description": { "user": "Response time in milliseconds from stimulus onset to key press." }
+    },
+    "correct": {
+      "description": { "user": "Whether the participant's response matched the correct answer (true/false)." }
+    }
+  }
+}
+```
+
+---
+
+## Top-level fields
+
+Any key not named `author` or `variables` is written directly to `dataset_description.json`. Commonly used fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | The name of the dataset. |
+| `description` | string | A plain-language description of the dataset. |
+| `license` | string | The license under which the data is shared (e.g. `"CC-BY-4.0"`). |
+| `citation` | string | A citation for the dataset or associated publication. |
+| `url` | string | A URL where the dataset can be found (e.g. OSF link). |
+| `funder` | string | Name of the funding body. |
+| `keywords` | array | List of keywords describing the study (e.g. `["attention", "inhibition"]`). |
+
+These correspond to [Schema.org Dataset](https://schema.org/Dataset) properties. Any valid Schema.org field can be included.
+
+---
+
+## Author fields
+
+The `author` key takes an object where each entry represents one author. The key you use for each author is their display name, which is also used as the `name` field if you don't specify one explicitly.
+
+```json
+{
+  "author": {
+    "Alex Johnson": {
+      "givenName": "Alex",
+      "familyName": "Johnson",
+      "identifier": "https://orcid.org/0000-0000-0000-0000"
+    },
+    "Sam Lee": {
+      "givenName": "Sam",
+      "familyName": "Lee"
+    }
+  }
+}
+```
+
+Accepted author fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | inferred | Full name. Defaults to the author's key if omitted. |
+| `givenName` | no | First name. |
+| `familyName` | no | Last name. |
+| `identifier` | no | A persistent identifier URL, such as an [ORCID](https://orcid.org/) (`https://orcid.org/...`). |
+
+---
+
+## Variable fields
+
+The `variables` key lets you enrich or override variable metadata that was auto-generated from your data files. Each entry is keyed by the exact column name as it appears in your CSV files.
+
+> **Note:** Variables listed here must already exist in your data. The tool generates a variable entry for every column it finds — the options file can only update those entries, not create new ones.
+
+```json
+{
+  "variables": {
+    "rt": {
+      "description": { "user": "Response time in milliseconds from stimulus onset to key press." },
+      "minValue": 0,
+      "maxValue": 5000
+    },
+    "correct": {
+      "description": { "user": "Whether the response was correct." },
+      "levels": ["true", "false"],
+      "levelsOrdered": false
+    },
+    "stimulus": {
+      "description": { "user": "The flanker arrow string shown on screen." }
+    }
+  }
+}
+```
+
+### The `description` field
+
+Variable descriptions use an object where each key identifies the source of the description and each value is the description text:
+
+```json
+"description": { "user": "My description here." }
+```
+
+Use `"user"` as the key for descriptions you write yourself. The tool uses plugin names (e.g. `"jsPsych-html-keyboard-response"`) as keys for descriptions it fetches automatically. Your `"user"` entry appears alongside auto-generated entries rather than replacing them, so the final description in `dataset_description.json` will show both.
+
+To replace a description entirely, open `dataset_description.json` after generation and edit the `description` field for that variable directly.
+
+### Accepted variable fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | object | Source-keyed description (see above). |
+| `minValue` | number | Minimum expected value for numeric variables. |
+| `maxValue` | number | Maximum expected value for numeric variables. |
+| `levels` | array | List of all possible values for categorical variables. |
+| `levelsOrdered` | boolean | Whether `levels` has a meaningful order (e.g. Likert scale). |
+| `na` | boolean | Whether missing values are present in this variable. |
+| `naValue` | string | The string used to represent missing values (e.g. `"NA"`, `"999"`). |
+| `alternateName` | string | An alternative name or abbreviation for the variable. |
+| `identifier` | string | A URL pointing to a formal definition of this variable. |
+| `privacy` | string | Notes on the sensitivity of this variable. |
+
+---
+
+## Tips
+
+- **You don't need to include every field.** The options file only needs to contain what you want to add or override — the rest is generated automatically from your data.
+- **Run the tool first without an options file**, then open `dataset_description.json` to see what was generated. Use the options file to fill in gaps (missing descriptions, author names, etc.) and re-run.
+- **Variable descriptions you write persist across re-runs.** When you update a project with `--psych-ds-dir`, the existing `dataset_description.json` is loaded first, so your custom descriptions are carried forward.

--- a/docs/what-is-psych-ds.md
+++ b/docs/what-is-psych-ds.md
@@ -1,0 +1,82 @@
+# What is Psych-DS?
+
+[Psych-DS](https://psych-ds.github.io/) is a community data standard for psychology and behavioral science research. It defines a set of conventions for how datasets should be organized and documented — consistent folder structure, file naming rules, and a machine-readable description file that travels with your data.
+
+This page explains what the standard involves and why it matters. For a hands-on guide to generating a Psych-DS compliant dataset from your jsPsych experiment, see [Getting Started](getting-started.md).
+
+---
+
+## The problem it solves
+
+Most behavioral science labs develop their own conventions for organizing data files: a folder structure that made sense at the time, filenames that seemed clear to whoever made them, a README that may or may not still be accurate. This works fine within a lab, but creates friction everywhere else:
+
+- A collaborator receives your data and spends days figuring out what each file contains.
+- You return to a dataset six months later and can't reconstruct what the columns mean.
+- A reviewer asks for raw data and your file structure doesn't match what the paper describes.
+- A meta-analyst wants to include your study but can't parse your variable names automatically.
+
+Psych-DS addresses this by giving datasets a predictable, documented structure that anyone — including software tools — can read without asking you questions first.
+
+---
+
+## The two core requirements
+
+### 1. File organization
+
+A Psych-DS compliant dataset has a specific folder layout:
+
+```
+my-experiment/
+├── dataset_description.json    ← machine-readable metadata about the dataset
+├── data/
+│   └── task-flanker_data.csv   ← your data files, named to a standard pattern
+└── data/raw/                   ← optional: original files in their earliest form
+```
+
+The `data/` folder holds your data files in CSV format. Each filename follows a `keyword-value_data.csv` pattern (e.g. `subject-01_data.csv`, `task-flanker_data.csv`) so that the role of each file is unambiguous. The `data/raw/` folder is for preserving originals — JSON exports, Excel workbooks, anything that isn't a clean CSV — and is ignored by the validator.
+
+### 2. A metadata file
+
+Every Psych-DS dataset includes a `dataset_description.json` file placed next to the `data/` folder. This is a JSON file that describes the dataset in a machine-readable way, using the [Schema.org](https://schema.org/) vocabulary so that the information is interpretable by any software that understands that standard.
+
+At minimum it must include:
+
+```json
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "name": "Flanker Study",
+  "description": "A description of the dataset.",
+  "variableMeasured": ["trial_type", "rt", "correct", "stimulus"]
+}
+```
+
+The `variableMeasured` field lists every column name that appears across all CSV files in the dataset. This is what makes the metadata machine-readable — a script or meta-analyst can open `dataset_description.json` and immediately know what variables the dataset contains, without opening a single data file.
+
+Richer metadata — author information, variable descriptions, measurement units, links to publications — can also be included and makes the dataset significantly more useful to others.
+
+---
+
+## Why this matters for jsPsych experiments
+
+jsPsych experiments produce structured tabular data, but the output files typically have ad-hoc names and no attached documentation. Psych-DS gives that data a standard home, and the `dataset_description.json` file is where the documentation lives.
+
+Because jsPsych plugins have consistent, documented parameter names, it's possible to automatically generate much of the `variableMeasured` content by reading the data and looking up what each column means in the plugin that produced it. That's what the jsPsych Metadata CLI does — it reads your experiment output and generates a `dataset_description.json` populated with variable descriptions drawn from the jsPsych plugin documentation.
+
+---
+
+## FAIR data principles
+
+Psych-DS is designed to help datasets meet the [FAIR principles](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4792175/) — a widely adopted framework for scientific data that stands for **Findable, Accessible, Interoperable, and Reusable**. A dataset that follows Psych-DS conventions is easier to find (it has a structured description), easier to use by others (the format is predictable), and easier to integrate into meta-analyses and automated pipelines.
+
+---
+
+## Further reading
+
+The official Psych-DS documentation covers the full specification in detail:
+
+- [Getting Started Guide](https://psychds-docs.readthedocs.io/en/latest/guides/1_getting_started/) — a walkthrough of the standard for researchers organizing data manually
+- [Rules and Conventions](https://psychds-docs.readthedocs.io/en/latest/reference/rules_and_conventions/) — complete specification of the naming rules and required fields
+- [Web Validator](https://psych-ds.github.io/validator/) — check any local dataset against the standard in your browser, with no data uploaded
+
+The jsPsych Metadata CLI automates the steps described in that getting started guide for jsPsych experiment data. See [Getting Started](getting-started.md) to try it.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,57 +1,144 @@
-# Metadata-CLI Module
+# Metadata CLI
 
-The metadata-cli module contains commands for interacting with the metadata-module to create and modify existing metadata according to [Psych-DS standards](https://psych-ds.github.io/). You can interact with the cli tool by running it with a graphical interface or by passing in the paths to you're data and metadata option .json files.
+A command-line tool for generating [Psych-DS](https://psych-ds.github.io/) compliant metadata for jsPsych experiments. Given a folder of jsPsych data files, it produces a `dataset_description.json` that describes your experiment and its variables according to the Psych-DS standard.
 
 ---
 
-## CLI with prompting (recommended)
+## What is Psych-DS?
 
-To run the CLI with prompting you can call ```npx @jspsych/metadata-cli```. This is the recommended way of running the package.
+[Psych-DS](https://psych-ds.github.io/) is a community standard for organizing and documenting psychology datasets. A Psych-DS compliant project has a predictable folder structure and a `dataset_description.json` file that describes the dataset, its authors, and the variables it contains. This makes your data easier to share, reproduce, and understand.
 
-This will then prompt you through the various CLI options, this includes generating from scratch or using an existing file. There are descriptions of how the files and directories should be structured below. 
+---
 
-## CLI without prompting and optional flags
-
-If you are findng the prompting steps to be more of a hinderance rather, then you can skip steps by directly passing in the arguments when calling npx. 
-
-An example is:
+## Quick start
 
 ```
-npx @jspsych/metadata-cli --verbose --psych-ds-dir=/path/to/existing/metadata/dir --data-dir=/path/to/data/dir --metadata-options=/path/to/metadata-options.json
+npx @jspsych/metadata-cli
 ```
 
-The ```--verbose``` flag when called will make the output more descriptive and will explain all the steps that are happening in more detail. This is only recommended when there is something going wrong and you need to get more information.
+Running the tool without any flags launches the interactive mode, which walks you through each step. This is the recommended way to use the tool.
 
-The ```--psych-ds-dir --data-dir --metadata-options``` flags all correspond to the different prompting steps. Using the example above, you are able to skip all prompting steps by entering the correct information. If any of these inputs are not valid the CLI will prompt you until you enter a valid input.
+---
 
-```--psych-ds-dir``` corresponds to an existing Psych-DS valid directory. This is to be used if want to update existing metadata.
+## Interactive walkthrough
 
-```--data-dir``` corresponds to the data folder that you want to use to update or create the metadata.
+When you run the CLI interactively, it guides you through the following steps:
 
-```--metadata-options``` corresponds to the options.json that you want to use to overwrite the defaults and update the existing metadata.
+### 1. Create a new project or update an existing one
+
+You will be asked whether you want to:
+
+- **Create a new project** — the tool creates a new Psych-DS folder structure and generates metadata from scratch.
+- **Update an existing project** — point the tool to a folder that already contains a `dataset_description.json` and it will load the existing metadata before updating it.
+
+### 2. Project name (new projects only)
+
+If creating a new project, you will be asked for a project name. This is used as the subfolder name and is written into the metadata.
+
+### 3. Path to your data folder
+
+Provide the path to the folder containing your jsPsych data files (`.csv` or `.json`). The tool reads one level of subdirectories. Your files will be **copied** into a `data/` subfolder inside the new project — your originals are not modified.
+
+### 4. Customize metadata (optional)
+
+You can optionally provide a metadata options file (see [Metadata options file](#metadata-options-file) below) to set fields like author names, variable descriptions, and other dataset-level information. If you skip this step you can always edit `dataset_description.json` directly or re-run the CLI later.
+
+### 5. Fill in unknown variable descriptions (optional)
+
+After processing your data files, the tool will flag any variables whose descriptions could not be automatically determined (for example, variables from custom plugins). You can type in descriptions for each one or press Enter to skip.
+
+### 6. Validation
+
+After saving, the tool validates the project against the Psych-DS specification and reports whether it passed, along with any errors or warnings.
+
+---
+
+## Generated project structure
+
+For a new project named `my-experiment`, the tool creates:
+
+```
+my-experiment/
+├── data/                         # copies of your raw data files
+├── dataset_description.json      # generated Psych-DS metadata
+├── README.md                     # placeholder for a human-readable description
+└── CHANGES.md                    # placeholder for version tracking
+```
+
+---
+
+## Flags and non-interactive mode
+
+All prompting steps can be skipped by passing the corresponding flags directly. If all three path flags are provided and valid, the tool runs fully non-interactively.
+
+```
+npx @jspsych/metadata-cli --psych-ds-dir=/path/to/existing/project --data-dir=/path/to/data --metadata-options=/path/to/options.json
+```
+
+| Flag | Alias | Description |
+|------|-------|-------------|
+| `--psych-ds-dir` | `-em` | Path to an existing Psych-DS project folder (must contain `dataset_description.json`). Use this to update existing metadata. |
+| `--data-dir` | `-d` | Path to the folder containing your jsPsych data files. |
+| `--metadata-options` | `-m` | Path to a metadata options `.json` file to customise the generated metadata. |
+| `--verbose` | `-v` | Print detailed output at each step. Useful for debugging. |
+
+If a flag is provided but invalid, the tool will fall back to prompting for that step.
+
+---
+
+## Metadata options file
+
+A metadata options file is a `.json` file that lets you set or override fields in the generated metadata. Any top-level key maps directly to a field in `dataset_description.json`. Authors and variables require a nested structure.
+
+### Example
+
+```json
+{
+  "name": "My Experiment",
+  "description": "A study on response times.",
+  "author": {
+    "Jane Smith": {
+      "name": "Jane Smith",
+      "givenName": "Jane",
+      "familyName": "Smith"
+    }
+  },
+  "variables": {
+    "rt": {
+      "description": {
+        "my-plugin": "Reaction time in milliseconds."
+      }
+    }
+  }
+}
+```
+
+---
+
+## Data file requirements
+
+- Files must be `.csv` or `.json` format generated by jsPsych.
+- The tool reads all files in the target folder and one level of subdirectories.
+- If a `dataset_description.json` is present in the data folder it will be loaded as existing metadata rather than treated as a data file.
+- Non-data files in the folder will be counted as failures but will not prevent the rest of the files from being processed.
+
+---
 
 ## Running the CLI locally
 
-To run the CLI locally, you will need to clone this repo and navigate to the CLI directory. To do this, you must have node installed and it is not recommended unless you have programming experience. This is best if you want to customize the CLI according to your specific use case or want to avoid using npm/npx. 
+For development or customisation, you can run the CLI directly from the source:
 
 1. Clone the repository.
-2. Navigate to the CLI directory.
-3. Install the necessary packages with ```npm install```.
-4. Build the cli file with ```npm run build```.
-5. Run the cli with ```npx .```.
+2. Navigate to `packages/cli`.
+3. Run `npm install`.
+4. Run `npm run build`.
+5. Run `npx .` to launch the CLI.
 
-## Common errors
+Node.js must be installed. This is only recommended if you have programming experience and want to modify the tool.
 
-### Path to data requirements  
+---
 
-The path that is given to the data must be a directory. If you are running the CLI without prompting, the ```dataset_description.json``` should be in the root directory. 
+## Naming requirements
 
-All the files in the data folder must be valid JsPsych-generated .csv and .json files. All the files that are in the directory will be scraped. If the data files are mixed in with other non-data files, there may be unintended errors. The CLI will scrape one level deep into the directories, but will not recurse infinitely. 
-
-### Metadata options requirements 
-
-The metadata-options file must be in .json format and needs to include the same 
-
-### Naming Requirements
-
-The ```dataset_description.json``` must be named as is according to Psych-DS specification, and the rest of the files must be organized as Psych-DS requirements.
+- The metadata file must be named exactly `dataset_description.json`.
+- Data files must be `.csv` or `.json`. Other file types will not be processed.


### PR DESCRIPTION
## Summary

Adds a `/docs` directory with four markdown pages for researchers (jsPsych users) unfamiliar with Psych-DS. Written with reference to the [official Psych-DS documentation](https://psychds-docs.readthedocs.io/en/latest/).

- **`docs/what-is-psych-ds.md`** — context page explaining what Psych-DS is, the problem it solves, the two core requirements (folder structure + `dataset_description.json`), why it matters for jsPsych experiments, and FAIR principles. Links to the official docs for deeper reading.
- **`docs/getting-started.md`** — full interactive walkthrough for researchers generating their first Psych-DS project, using a concrete flanker-task example. Covers the complete CLI flow including Psych-DS filename normalization, JSON→CSV conversion, `data/raw/` structure, validation output, and next steps.
- **`docs/cli-reference.md`** — flags reference table, non-interactive mode with a shell script example, exit codes, filename naming rules with valid/invalid examples and the full keywords table, and validation output explained.
- **`docs/metadata-options.md`** — format reference for the options file, covering top-level Schema.org fields, author fields (including ORCID), and the full variable fields type with notes on how description source-keying works.

Also rewrites `packages/cli/README.md` with the full interactive flow, flag reference, metadata options format, and data file requirements.

## Intended audience

Researchers using jsPsych who want to organize and share their experiment data. Not developers.

## Test plan

- [ ] Walk through `docs/getting-started.md` with a real jsPsych data folder and verify each step matches actual CLI behaviour
- [ ] Check that flag descriptions in `docs/cli-reference.md` match current `--help` output
- [ ] Verify filename valid/invalid examples against the validator