### PR TITLE
fix(cli): normalize path separators for Psych-DS validator on Windows

### DIFF
--- a/.changeset/fix-validator-windows-path.md
+++ b/.changeset/fix-validator-windows-path.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata-cli": patch
+---
+
+Fix Psych-DS validation always failing on Windows. The relative path passed to the validator contained backslashes on Windows, which the validator could not resolve — causing spurious MISSING_DATAFILE and MISSING_DATASET_DESCRIPTION errors even when the project was generated correctly. Normalize path separators to forward slashes before validation.

--- a/packages/cli/src/validatefunctions.ts
+++ b/packages/cli/src/validatefunctions.ts
@@ -28,7 +28,7 @@ export function parseMissingFields(issues: Map<string, any>, key: string): strin
 export const validatePsychDS = async (datasetPath: string, verbose: boolean): Promise<PsychDSValidationResult> => {
   let result;
   try {
-    result = await validate(path.relative(process.cwd(), datasetPath));
+    result = await validate(path.relative(process.cwd(), datasetPath).replace(/\\/g, '/'));
   } catch (err) {
     console.warn(`\nWarning: Psych-DS validation could not run: ${err instanceof Error ? err.message : err}`);
     return { hasErrors: false, missingRequiredFields: [], missingRecommendedFields: [] };

--- a/packages/cli/tests/validatefunctions.test.ts
+++ b/packages/cli/tests/validatefunctions.test.ts
@@ -83,7 +83,7 @@ describe("validatePsychDS", () => {
   test("prints ✔ line when validation passes with no warnings", async () => {
     mockValidate.mockResolvedValue(makeResult([]));
     const result = await validatePsychDS("/some/dataset", false);
-    expect(mockValidate).toHaveBeenCalledWith(path.relative(process.cwd(), "/some/dataset"));
+    expect(mockValidate).toHaveBeenCalledWith(path.relative(process.cwd(), "/some/dataset").replace(/\\/g, '/'));
     expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (0 warnings).");
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).not.toHaveBeenCalled();

--- a/packages/cli/tests/validatefunctions.test.ts
+++ b/packages/cli/tests/validatefunctions.test.ts
@@ -83,12 +83,25 @@ describe("validatePsychDS", () => {
   test("prints ✔ line when validation passes with no warnings", async () => {
     mockValidate.mockResolvedValue(makeResult([]));
     const result = await validatePsychDS("/some/dataset", false);
-    expect(mockValidate).toHaveBeenCalledWith(path.relative(process.cwd(), "/some/dataset").replace(/\\/g, '/'));
+    // On POSIX the relative path already uses forward slashes, so normalization is a no-op
+    // and must leave the path untouched (asserted against the un-normalized relative path).
+    expect(mockValidate).toHaveBeenCalledWith(path.relative(process.cwd(), "/some/dataset"));
     expect(logSpy).toHaveBeenCalledWith("\n✔ Psych-DS validation passed (0 warnings).");
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).not.toHaveBeenCalled();
     expect(errorSpy).not.toHaveBeenCalled();
     expect(result).toEqual({ hasErrors: false, missingRequiredFields: [], missingRecommendedFields: [] });
+  });
+
+  test("normalizes Windows backslash separators to forward slashes before validating", async () => {
+    // Simulate path.relative returning a Windows-style path so the fix is exercised on any host OS.
+    const relativeSpy = jest
+      .spyOn(path, "relative")
+      .mockReturnValue("..\\TestingPsychDSOutput\\testDocs\\testProject");
+    mockValidate.mockResolvedValue(makeResult([]));
+    await validatePsychDS("/some/dataset", false);
+    expect(mockValidate).toHaveBeenCalledWith("../TestingPsychDSOutput/testDocs/testProject");
+    relativeSpy.mockRestore();
   });
 
   test("prints ✘ line and each error when errors are present", async () => {


### PR DESCRIPTION
## Summary

Fixes Psych-DS validation always failing on Windows with spurious errors:

```
✘ Psych-DS validation failed: 2 errors, 10 warnings.
  Error 1: MISSING_DATAFILE: No CSV or TSV files were found in the data subdirectory...
  Error 2: MISSING_DATASET_DESCRIPTION: It is required to include a 'dataset_description.json'...
```

These errors appeared even when the project was generated correctly (files saved, data copied). The root cause: `path.relative()` on Windows produces backslash-separated paths (e.g. `..\TestingPsychDSOutput\testDocs\testProject`), which the `psychds-validator` cannot resolve.

**Fix:** normalize backslashes to forward slashes before passing the path to `validate()`.

Found during smoke-testing of the getting-started docs on Windows.

## Test plan

- [x] All 76 existing tests pass
- [ ] Re-run `npx @jspsych/metadata-cli` on Windows and confirm validation no longer reports false errors