### PR TITLE
fix(cli): patch platform.path.join to fix validation always failing on Windows

### DIFF
--- a/.changeset/fix-validator-path-join.md
+++ b/.changeset/fix-validator-path-join.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata-cli": patch
+---
+
+Fix Psych-DS validation always reporting MISSING_DATAFILE and MISSING_DATASET_DESCRIPTION on Windows. The validator's platform shim used Array.join("/") as a path.join fallback, producing double-slash file paths ("//dataset_description.json") that did not match the validator's exact-string checks. Patch platform.path.join to deduplicate consecutive forward slashes before calling validate().

--- a/packages/cli/src/validatefunctions.ts
+++ b/packages/cli/src/validatefunctions.ts
@@ -26,6 +26,23 @@ export function parseMissingFields(issues: Map<string, any>, key: string): strin
 }
 
 export const validatePsychDS = async (datasetPath: string, verbose: boolean): Promise<PsychDSValidationResult> => {
+  // psychds-validator's platform shim uses a POSIX fallback for path.join that calls
+  // Array.join("/"), so path.join("/", "file") produces "//file". The validator matches
+  // files by exact path (e.g. file.path === "/dataset_description.json"), so the double
+  // slash breaks all file lookups. Patch the exported path object to deduplicate consecutive
+  // forward slashes. Reaches into an internal module path; guarded by try/catch so
+  // validation still runs (with degraded path matching) if the path ever changes.
+  try {
+    // psychds-validator's exports field blocks subpath imports, so we resolve the main
+    // CJS entry point and navigate to platform.js from there. require() with an absolute
+    // path hits the module cache, so we get the same object instance that deno.js holds.
+    const validatorMain = require.resolve("psychds-validator");
+    const platformPath = path.join(path.dirname(validatorMain), "utils", "platform.js");
+    const platform = require(platformPath) as any;
+    platform.path.join = (...parts: string[]) =>
+      (parts as string[]).join('/').replace(/\/+/g, '/') || '/';
+  } catch { /* ignore */ }
+
   let result;
   try {
     result = await validate(path.relative(process.cwd(), datasetPath).replace(/\\/g, '/'));

--- a/packages/cli/tests/validatefunctions.test.ts
+++ b/packages/cli/tests/validatefunctions.test.ts
@@ -104,6 +104,20 @@ describe("validatePsychDS", () => {
     relativeSpy.mockRestore();
   });
 
+  test("patches platform path.join to deduplicate forward slashes", async () => {
+    // The validator's platform shim fallback produces "//file" for path.join("/", "file"),
+    // breaking exact-path checks like file.path === "/dataset_description.json".
+    // Verify the patch makes path.join("/", "file") === "/file".
+    mockValidate.mockResolvedValue(makeResult([]));
+    await validatePsychDS("/some/dataset", false);
+    const validatorMain = require.resolve("psychds-validator");
+    const platformPath = path.join(path.dirname(validatorMain), "utils", "platform.js");
+    const platform = require(platformPath);
+    expect(platform.path.join("/", "dataset_description.json")).toBe("/dataset_description.json");
+    expect(platform.path.join("/", "data")).toBe("/data");
+    expect(platform.path.join("/data", "file.csv")).toBe("/data/file.csv");
+  });
+
   test("prints ✘ line and each error when errors are present", async () => {
     mockValidate.mockResolvedValue(makeResult([
       { severity: "error", key: "MISSING_FIELD", reason: "field is required" },


### PR DESCRIPTION
## Summary

- Fixes `MISSING_DATAFILE` and `MISSING_DATASET_DESCRIPTION` always appearing on Windows even when the project is generated correctly
- Root cause: `psychds-validator`'s platform shim uses `Array.join("/")` as a `path.join` fallback, producing `"//dataset_description.json"` instead of `"/dataset_description.json"` — the validator matches files by exact path, so the double slash breaks all file lookups
- Fix: resolve the validator's CJS `platform.js` via `require.resolve` (bypasses the package `exports` restriction on subpath imports) and patch `platform.path.join` to deduplicate consecutive forward slashes
- Adds a test confirming the patch is applied and produces correct output

Closes #56

## Test plan

- [ ] Run `npm test` in `packages/cli` — all existing tests should pass, new test should pass
- [ ] Build and run the CLI on Windows against a real dataset — validation should no longer report `MISSING_DATAFILE` / `MISSING_DATASET_DESCRIPTION` on a correctly generated project

🤖 Generated with [Claude Code](https://claude.com/claude-code)