### PR TITLE
fix(metadata): don't misdetect whitespace-only strings as numeric (#70)

### DIFF
--- a/.changeset/fix-whitespace-numeric-coercion.md
+++ b/.changeset/fix-whitespace-numeric-coercion.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata": patch
+---
+
+Fix whitespace-only string values being misdetected as numeric (#70). A cell containing only whitespace (e.g. a single space) passed the `isNaN(Number(value))` check because `Number(" ")` is `0`, but `parseFloat(" ")` is `NaN` — leaking through as `NaN` `minValue`/`maxValue` (serialized to `null`) on otherwise-categorical string columns. The numeric check now requires non-empty trimmed content and uses `Number` for both the test and the conversion so they cannot disagree.

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -496,9 +496,16 @@ export default class JsPsychMetadata {
 
       // handling type conversion from csv by converting back into number, should think about booleans as well
       if (type === "string") {
-        if (!isNaN(Number(value))) {
+        // Number("") and Number(" ") are both 0, so a whitespace-only string would otherwise be
+        // misdetected as numeric. Require non-empty trimmed content, and use Number (not parseFloat)
+        // for the conversion so the numeric test and the stored value never disagree — parseFloat(" ")
+        // is NaN, which previously leaked through as NaN min/max (serialized as null) for string columns.
+        const asNumber = Number(value);
+        // Number.isFinite (not !isNaN) also rejects "Infinity"/"-Infinity", which would otherwise
+        // serialize to null min/max. The trim guard is still needed because Number(" ") is 0 (finite).
+        if (value.trim() !== "" && Number.isFinite(asNumber)) {
           type = "number";
-          value = parseFloat(value);
+          value = asNumber;
         } else if (value.toLowerCase() === "true" || value.toLowerCase() === "false") {
           type = "boolean";
           value = (value.toLowerCase() === "true");

--- a/packages/metadata/tests/metadata-module.test.ts
+++ b/packages/metadata/tests/metadata-module.test.ts
@@ -1,5 +1,52 @@
 import JsPsychMetadata from "../src/index";
 
+// Regression for #70: a whitespace-only cell (e.g. a single space) must not be misdetected as
+// numeric. Number(" ") === 0 passes the old isNaN(Number(value)) check, but parseFloat(" ") is NaN,
+// which leaked through as NaN min/max (serialized to null) on otherwise-categorical string columns.
+describe("whitespace-only values are not treated as numeric (#70)", () => {
+  let jsPsychMetadata: JsPsychMetadata;
+
+  beforeEach(() => {
+    jsPsychMetadata = new JsPsychMetadata();
+  });
+
+  test("a string column with a whitespace-only cell stays categorical with no NaN/null min/max", async () => {
+    const csv = [
+      "trial_type,response",
+      "html-keyboard-response,Enter",
+      "html-keyboard-response, ", // single-space response
+      "html-keyboard-response,p",
+    ].join("\n");
+
+    await jsPsychMetadata.generate(csv, {}, "csv");
+
+    const variableMeasured = jsPsychMetadata.getMetadata()["variableMeasured"] as any[];
+    const response = variableMeasured.find((v) => v.name === "response");
+
+    expect(response.value).toBe("string");
+    expect(response).not.toHaveProperty("minValue");
+    expect(response).not.toHaveProperty("maxValue");
+    // The whitespace cell is recorded as a level, not silently turned into a NaN number.
+    expect(response.levels).toEqual(expect.arrayContaining(["Enter", "p", " "]));
+  });
+
+  test("genuinely numeric string columns are still coerced to numbers", async () => {
+    const csv = [
+      "trial_type,rt",
+      "html-keyboard-response,450",
+      "html-keyboard-response,512",
+    ].join("\n");
+
+    await jsPsychMetadata.generate(csv, {}, "csv");
+
+    const rt = (jsPsychMetadata.getMetadata()["variableMeasured"] as any[]).find((v) => v.name === "rt");
+    expect(rt.value).toBe("number");
+    expect(rt.minValue).toBe(450);
+    expect(rt.maxValue).toBe(512);
+    expect(rt).not.toHaveProperty("levels");
+  });
+});
+
 describe("always-empty columns in variableMeasured", () => {
   let jsPsychMetadata: JsPsychMetadata;
 


### PR DESCRIPTION
## Summary
Fixes #70 — whitespace-only string cells (e.g. a single space `" "`) were misdetected as numeric, producing `NaN` `minValue`/`maxValue` that `JSON.stringify` serializes as `null` on otherwise-categorical string columns.

Root cause (`packages/metadata/src/index.ts`): `Number(" ") === 0`, so a whitespace-only string passed the `isNaN(Number(value))` check — but `parseFloat(" ") === NaN`. The column was then typed `number` and `updateMinMax` was called with `NaN`, which stayed `NaN` (since `NaN > x` / `NaN < x` are always false) and serialized to `null`.

## Fix
- Require **non-empty trimmed content** before treating a string as numeric (catches `" "`, since `Number(" ")` and `Number("")` are both `0`).
- Use `Number` for **both** the test and the conversion, so they can never disagree the way `Number(" ")`/`parseFloat(" ")` did.
- Use `Number.isFinite` instead of `!isNaN`, which also rejects `"Infinity"`/`"-Infinity"` (same `null` min/max class).

## Real-data verification
Found and verified against a real Tobii eye-tracking dataset (DataPipe export). The `response` column had 1002 string values (`"Enter"`, `"p"`, `"a"`, …) plus 30 single-space cells. Before: `{"value":"string","minValue":null,"maxValue":null, ...}`. After: clean `{"value":"string","levels":["Enter"," ","p", ...]}`, no spurious min/max. Numeric columns (`rt`, `time_elapsed`, `trial_index`) are unaffected.

## Behavior change worth noting
Strings with trailing units like `"5px"` previously coerced to numbers (`parseFloat("5px") === 5`); they now stay **strings** (`Number("5px")` is `NaN`). This is more correct — a trailing-unit string isn't numeric — but it is a behavior change, called out here for reviewers.

## Tests
- Added 2 regression tests: a whitespace-only cell stays categorical with no min/max; genuinely numeric string columns still coerce to numbers.
- Full metadata suite: **67/67 pass**.
- Changeset added (`@jspsych/metadata`: patch).

## Out of scope
Mixed-type columns (a column with both numbers and strings, e.g. `block_number` = 1–4 + `"Practice"`) still produce both min/max and levels — tracked separately in #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
