### PR TITLE
feat(metadata): recursively unnest deep objects and extract nested arrays

### DIFF
--- a/.changeset/deep-unnest-nested-objects.md
+++ b/.changeset/deep-unnest-nested-objects.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata": minor
+---
+
+Recursively expand nested JSON objects more than one level deep. Previously `expandObjectFields` only expanded a single level, so a value like `response: {"Q0":{"score":4,"meta":{"valid":true}}}` registered `response.Q0` as an opaque `value:"object"` leaf and lost its sub-fields. Now nested plain objects are fully expanded into dotted sub-variables (`response.Q0.score`, `response.Q0.meta.valid`) with correct types and min/max/levels tracking at any depth. Arrays nested inside objects are now correctly typed as `value:"array"` instead of `"object"`, and nested arrays-of-objects are extracted into their own Psych-DS CSV files keyed by their dotted column name — mirroring how top-level array columns are handled.

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -474,6 +474,10 @@ export default class JsPsychMetadata {
 
     if (extensionType) this.generateDefaultExtensionVariables(); // After first call, generation is stopped
 
+    // Join key values for this row, shared by every array column (top-level or nested)
+    // extracted into a separate CSV during this observation.
+    const joinValues = this.arrayJoinKeys.reduce((acc, k) => { acc[k] = observation[k]; return acc; }, {} as Record<string, any>);
+
     for (const variable in observation) {
       var value = observation[variable];
       var type: string = typeof value;
@@ -515,29 +519,14 @@ export default class JsPsychMetadata {
         this.updateFields(variable, value, type);
       } else {
         if (type === "object" && value !== null && !Array.isArray(value)) {
-          await this.expandObjectFields(variable, value, pluginType, version);
+          await this.expandObjectFields(variable, value, pluginType, version, joinValues);
         } else if (type === "array" || (type === "object" && Array.isArray(value))) {
           // Register parent via generateMetadata to get the plugin description, then
           // override the stored type to "array" (generateMetadata would infer "object"
           // because typeof [] === "object" in JS).
           await this.generateMetadata(variable, value, pluginType, version);
           this.updateVariable(variable, "value", "array");
-
-          // Accumulate array-of-objects rows for separate CSV output.
-          // Only object elements are expanded; null / primitive elements are skipped.
-          const objectElements = (value as any[]).filter(
-            (el) => el !== null && typeof el === "object" && !Array.isArray(el)
-          );
-          if (objectElements.length > 0) {
-            const joinValues = this.arrayJoinKeys.reduce((acc, k) => { acc[k] = observation[k]; return acc; }, {} as Record<string, any>);
-            const existing = this.extractedArrays.get(variable) ?? [];
-            (value as any[]).forEach((element, elementIndex) => {
-              if (element !== null && typeof element === "object" && !Array.isArray(element)) {
-                existing.push({ ...joinValues, element_index: elementIndex, ...element });
-              }
-            });
-            this.extractedArrays.set(variable, existing);
-          }
+          this.accumulateArrayColumn(variable, value as any[], joinValues);
         } else {
           await this.generateMetadata(variable, value, pluginType, version);
         }
@@ -700,18 +689,62 @@ export default class JsPsychMetadata {
   }
 
   /**
-   * Registers the top-level keys of a plain JSON object as dotted sub-variables
+   * Registers the keys of a plain JSON object as dotted sub-variables
    * (e.g. response.Q0, response.Q1) and registers the parent with value: "object".
-   * One level deep only.
+   *
+   * Recurses into nested plain objects so structures more than one level deep are
+   * fully expanded (e.g. response.address.city). Nested arrays are registered with
+   * value: "array" (typeof [] === "object", so the inferred type must be overridden)
+   * and, when they hold objects, extracted into a separate CSV keyed by their dotted
+   * column name — mirroring how top-level array columns are handled.
+   *
+   * @param joinValues - The current row's join key values, prepended to every
+   *   extracted nested-array row so the sub-table can be rejoined to the main data.
    */
-  private async expandObjectFields(parentName: string, obj: Record<string, any>, pluginType: string, version: string) {
+  private async expandObjectFields(parentName: string, obj: Record<string, any>, pluginType: string, version: string, joinValues: Record<string, any>) {
     // Register the parent through the normal path so the plugin description is fetched.
     // typeof obj === "object", so generateMetadata stores value: "object" and updateFields
     // skips levels automatically — no override needed.
     await this.generateMetadata(parentName, obj, pluginType, version);
     for (const key of Object.keys(obj)) {
-      await this.generateMetadata(`${parentName}.${key}`, obj[key], pluginType, version);
+      const childName = `${parentName}.${key}`;
+      const childValue = obj[key];
+
+      if (childValue !== null && typeof childValue === "object" && !Array.isArray(childValue)) {
+        // Nested plain object — recurse so its keys are expanded too.
+        await this.expandObjectFields(childName, childValue, pluginType, version, joinValues);
+      } else if (Array.isArray(childValue)) {
+        // Nested array — register the description, override the inferred "object" type,
+        // and extract any object elements into a separate CSV.
+        await this.generateMetadata(childName, childValue, pluginType, version);
+        this.updateVariable(childName, "value", "array");
+        this.accumulateArrayColumn(childName, childValue, joinValues);
+      } else {
+        await this.generateMetadata(childName, childValue, pluginType, version);
+      }
     }
+  }
+
+  /**
+   * Accumulates the object elements of an array column into `extractedArrays` for
+   * separate Psych-DS CSV output, keyed by the column's (possibly dotted) name.
+   * Each emitted row is the join key values, an `element_index`, then the element's
+   * own fields. Null / primitive elements are skipped; arrays with no object
+   * elements produce no rows.
+   */
+  private accumulateArrayColumn(columnName: string, arr: any[], joinValues: Record<string, any>) {
+    const hasObjectElements = arr.some(
+      (el) => el !== null && typeof el === "object" && !Array.isArray(el)
+    );
+    if (!hasObjectElements) return;
+
+    const existing = this.extractedArrays.get(columnName) ?? [];
+    arr.forEach((element, elementIndex) => {
+      if (element !== null && typeof element === "object" && !Array.isArray(element)) {
+        existing.push({ ...joinValues, element_index: elementIndex, ...element });
+      }
+    });
+    this.extractedArrays.set(columnName, existing);
   }
 
   /**

--- a/packages/metadata/tests/metadata-nested-columns.test.ts
+++ b/packages/metadata/tests/metadata-nested-columns.test.ts
@@ -111,6 +111,114 @@ describe("Nested JSON column handling", () => {
     });
   });
 
+  // ─── Case 1b: deeply nested JSON objects (>2 levels) ─────────────────────────
+
+  describe("deeply nested JSON object columns", () => {
+    test("objects more than one level deep are fully expanded with dotted names", async () => {
+      const data = JSON.stringify([
+        { ...BASE, response: { Q0: { score: 4, meta: { valid: true } } } },
+      ]);
+      const meta = new JsPsychMetadata();
+      await meta.generate(data);
+
+      const names = meta.getVariableNames();
+      expect(names).toContain("response.Q0.score");
+      expect(names).toContain("response.Q0.meta.valid");
+    });
+
+    test("intermediate object nodes are registered with value: 'object' and no levels", async () => {
+      const data = JSON.stringify([
+        { ...BASE, response: { Q0: { score: 4, meta: { valid: true } } } },
+      ]);
+      const meta = new JsPsychMetadata();
+      await meta.generate(data);
+
+      for (const node of ["response", "response.Q0", "response.Q0.meta"]) {
+        const v = meta.getVariable(node) as any;
+        expect(v.value).toBe("object");
+        expect(v.levels).toBeUndefined();
+      }
+    });
+
+    test("deep numeric leaves still track minValue and maxValue", async () => {
+      const data = JSON.stringify([
+        { ...BASE, response: { Q0: { score: 2 } } },
+        { ...BASE, trial_index: 1, time_elapsed: 200, response: { Q0: { score: 9 } } },
+      ]);
+      const meta = new JsPsychMetadata();
+      await meta.generate(data);
+
+      const v = meta.getVariable("response.Q0.score") as any;
+      expect(v.value).toBe("number");
+      expect(v.minValue).toBe(2);
+      expect(v.maxValue).toBe(9);
+    });
+
+    test("deep string leaves still accumulate levels", async () => {
+      const data = JSON.stringify([
+        { ...BASE, response: { Q0: { label: "yes" } } },
+        { ...BASE, trial_index: 1, time_elapsed: 200, response: { Q0: { label: "no" } } },
+      ]);
+      const meta = new JsPsychMetadata();
+      await meta.generate(data);
+
+      const v = meta.getVariable("response.Q0.label") as any;
+      expect(v.value).toBe("string");
+      expect(v.levels).toContain("yes");
+      expect(v.levels).toContain("no");
+    });
+
+    test("arrays nested inside objects are typed as 'array', not 'object'", async () => {
+      const data = JSON.stringify([
+        { ...BASE, response: { Q0: { points: [1, 2, 3] } } },
+      ]);
+      const meta = new JsPsychMetadata();
+      await meta.generate(data);
+
+      const v = meta.getVariable("response.Q0.points") as any;
+      expect(v.value).toBe("array");
+      expect(v.levels).toBeUndefined();
+    });
+
+    test("nested arrays-of-objects are extracted to a CSV keyed by their dotted name", async () => {
+      const data = JSON.stringify([
+        { ...BASE, response: { samples: [{ x: 1, y: 2 }, { x: 3, y: 4 }] } },
+      ]);
+      const meta = new JsPsychMetadata();
+      await meta.generate(data);
+
+      const extracted = meta.getExtractedArrays();
+      expect(extracted.has("response.samples")).toBe(true);
+      const rows = extracted.get("response.samples")!;
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toMatchObject({ trial_index: 0, element_index: 0, x: 1, y: 2 });
+      expect(rows[1]).toMatchObject({ trial_index: 0, element_index: 1, x: 3, y: 4 });
+    });
+
+    test("nested arrays of primitives are typed 'array' but not extracted", async () => {
+      const data = JSON.stringify([
+        { ...BASE, response: { Q0: { points: [1, 2, 3] } } },
+      ]);
+      const meta = new JsPsychMetadata();
+      await meta.generate(data);
+
+      expect(meta.getExtractedArrays().has("response.Q0.points")).toBe(false);
+    });
+
+    test("CSV input: deeply nested JSON object string is detected and expanded", async () => {
+      const csv = [
+        "trial_type,trial_index,time_elapsed,response",
+        'mock-plugin,0,100,"{""Q0"":{""score"":4,""meta"":{""valid"":true}}}"',
+      ].join("\n");
+      const meta = new JsPsychMetadata();
+      await meta.generate(csv, {}, "csv");
+
+      const names = meta.getVariableNames();
+      expect(names).toContain("response.Q0.score");
+      expect(names).toContain("response.Q0.meta.valid");
+    });
+  });
+
   // ─── Case 2: JSON arrays of objects ─────────────────────────────────────────
 
   describe("JSON array-of-objects columns", () => {


### PR DESCRIPTION
## Summary

Resolves the "deeper than 2 levels" unnesting limitation. `expandObjectFields` was **one level deep only** — a nested object child was registered as an opaque `value:"object"` leaf and its sub-fields were lost, and arrays nested inside objects were mistyped as `"object"`.

Now:
- **Recursive object expansion** — nested plain objects are expanded into dotted sub-variables at any depth (e.g. `response.Q0.meta.valid`) with full type / min-max / levels tracking.
- **Correct nested-array typing** — arrays nested inside objects are typed `value:"array"` (the inferred `"object"` is overridden, fixing a latent mistyping bug).
- **Nested array-of-objects extraction** — extracted into their own Psych-DS CSV keyed by the dotted column name (e.g. `validation_data.pointData`), mirroring top-level array handling. This needed **no CLI changes**: the write loop in `data.ts` is generic over `getExtractedArrays()`, and `deriveArrayFilename`→`toPsychDSValue` already collapses dotted names to camelCase.
- **Refactor** — array-accumulation logic is factored into a shared `accumulateArrayColumn` helper used by both the top-level and nested branches; `joinValues` is computed once per observation.

## Test plan

- Added a "deeply nested JSON object columns" block to `metadata-nested-columns.test.ts`: deep expansion, intermediate-node typing (`value:"object"`, no levels), deep numeric min/max, deep string levels, nested-array typing, nested array-of-objects extraction, nested-primitive-array *not* extracted, and CSV-input deep expansion. **73/73 tests pass.**
- Ran the built bundle over 38 real eyetracking files (26–70 MB each): **38/38 processed with no errors**. `validation_data.pointData` (a nested array-of-objects) now types as `array` and extracts to a CSV (45 rows) vs. the old code mistyping it `object` and dropping it.

> Note: this dataset's depth runs object→array→object, so the real-data run exercises the nested-array path + large-file robustness; the recursive-object-expansion path is covered by the unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)