### PR TITLE
fix(metadata): remove stale tsconfig paths entry and fix parseCSV typo

### DIFF
--- a/.changeset/csv-parse-browser-esm.md
+++ b/.changeset/csv-parse-browser-esm.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata": patch
+---
+
+Switch csv-parse import to the browser/esm build so the metadata package can run in a browser environment without Node-specific internals. Jest is redirected to the CJS build via a moduleNameMapper override since the ESM build requires transformation that Jest skips for node_modules.

--- a/.changeset/csv-parse-browser-esm.md
+++ b/.changeset/csv-parse-browser-esm.md
@@ -2,4 +2,4 @@
 "@jspsych/metadata": patch
 ---
 
-Switch csv-parse import to the browser/esm build so the metadata package can run in a browser environment without Node-specific internals. Jest is redirected to the CJS build via a moduleNameMapper override since the ESM build requires transformation that Jest skips for node_modules.
+Fix stray empty-string expression in parseCSV and remove stale tsconfig paths entry for csv-parse/browser/esm (was pointing to a non-existent path in the installed csv-parse version).

--- a/packages/metadata/jest.config.cjs
+++ b/packages/metadata/jest.config.cjs
@@ -1,11 +1,1 @@
-const baseConfig = require("@jspsych/config/jest").makePackageConfig(__dirname);
-
-module.exports = {
-  ...baseConfig,
-  moduleNameMapper: {
-    ...baseConfig.moduleNameMapper,
-    // csv-parse/browser/esm ships as ESM; Jest can't load it untransformed.
-    // Redirect to the CJS build for tests — Vite resolves the real ESM build via package.json exports.
-    "^csv-parse/browser/esm$": "<rootDir>/../../node_modules/csv-parse/dist/cjs/index.cjs",
-  },
-};
+module.exports = require("@jspsych/config/jest").makePackageConfig(__dirname);

--- a/packages/metadata/jest.config.cjs
+++ b/packages/metadata/jest.config.cjs
@@ -1,1 +1,11 @@
-module.exports = require("@jspsych/config/jest").makePackageConfig(__dirname);
+const baseConfig = require("@jspsych/config/jest").makePackageConfig(__dirname);
+
+module.exports = {
+  ...baseConfig,
+  moduleNameMapper: {
+    ...baseConfig.moduleNameMapper,
+    // csv-parse/browser/esm ships as ESM; Jest can't load it untransformed.
+    // Redirect to the CJS build for tests — Vite resolves the real ESM build via package.json exports.
+    "^csv-parse/browser/esm$": "<rootDir>/../../node_modules/csv-parse/dist/cjs/index.cjs",
+  },
+};

--- a/packages/metadata/src/utils.ts
+++ b/packages/metadata/src/utils.ts
@@ -1,4 +1,4 @@
-import { parse } from 'csv-parse';
+import { parse } from 'csv-parse/browser/esm';
 
 // private function to save text file on local drive
 export function saveTextToFile(textstr: string, filename: string) {
@@ -185,7 +185,7 @@ export function analyzeJoinKeys(
   };
 }
 
-export async function parseCSV(input) {''
+export async function parseCSV(input) {
   if (!parse) {
     throw new Error('Parser module not loaded');
   }

--- a/packages/metadata/src/utils.ts
+++ b/packages/metadata/src/utils.ts
@@ -1,4 +1,4 @@
-import { parse } from 'csv-parse/browser/esm';
+import { parse } from 'csv-parse';
 
 // private function to save text file on local drive
 export function saveTextToFile(textstr: string, filename: string) {

--- a/packages/metadata/tsconfig.json
+++ b/packages/metadata/tsconfig.json
@@ -4,9 +4,6 @@
     "target": "ES2018",
     "module": "ES2020",
     "moduleResolution": "node",
-    "paths": {
-      "csv-parse/browser/esm": ["../../node_modules/csv-parse/dist/esm/index.js"]
-    },
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declaration": true,

--- a/packages/metadata/tsconfig.json
+++ b/packages/metadata/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "ES2020",
     "moduleResolution": "node",
     "paths": {
-      "csv-parse/browser/esm": ["node_modules/csv-parse/lib/browser/esm/index.d.ts"]
+      "csv-parse/browser/esm": ["../../node_modules/csv-parse/dist/esm/index.js"]
     },
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

- Removes the stale `csv-parse/browser/esm` entry from `tsconfig.json` `paths` — it was pointing to `lib/browser/esm/index.d.ts` which doesn't exist in the installed csv-parse v5 (moved to `dist/esm`). The source import uses plain `csv-parse` and esbuild's existing alias config already handles the `→ browser/esm` substitution at build time for all browser targets, so this paths entry was dead code.
- Removes a stray empty-string expression (`{''`) in `parseCSV`

## Test plan

- [ ] All 186 previously-passing tests still pass (2 pre-existing failures in `validate-integration` and `validatefunctions` path-separator test are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)