### PR TITLE
fix(frontend): fix button and text colors on dark background

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -17,9 +17,15 @@ html, body {
 /* APp Page */
 .appPage {
   background-color: #3e3e3e;
+  color: rgba(255, 255, 255, 0.87);
   border: none;
   width: 100vw;
   height: 100vh;
+}
+
+.appPage button {
+  background-color: #1a1a1a;
+  color: rgba(255, 255, 255, 0.87);
 }
 
 /* src/components/EditPopup.css */
@@ -152,6 +158,17 @@ html, body {
 /* Metadata options */
 .optionsButton {
   margin: 10px;
+  background-color: #646cff;
+  color: white;
+  padding: 0.6em 1.5em;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.optionsButton:hover {
+  background-color: #535bf2;
 }
 
 /* DataFormPage */
@@ -211,6 +228,38 @@ html, body {
   height: 22px;
   border-radius: 5px;
   background: none;
+}
+
+/* Upload flow action buttons */
+
+.upload-continue {
+  background-color: #646cff;
+  color: white;
+  padding: 0.7em 2.2em;
+  font-size: 1.05em;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.upload-continue:hover {
+  background-color: #535bf2;
+}
+
+.upload-back {
+  background-color: #4a4a4a;
+  color: rgba(255, 255, 255, 0.87);
+  padding: 0.7em 2.2em;
+  font-size: 1.05em;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.upload-back:hover {
+  background-color: #5a5a5a;
 }
 
 /* Button Container */


### PR DESCRIPTION
## Summary

- Adds `color: rgba(255, 255, 255, 0.87)` to `.appPage` so all text inside the dark background is white regardless of the OS light/dark mode setting
- Adds `.appPage button` override to prevent the `index.css` light-mode rule (`background-color: #f9f9f9`) from producing white buttons on the dark gray page
- Styles `.upload-continue` and `.upload-back` with the existing `#646cff` accent color (primary/secondary distinction)
- Styles `.optionsButton` consistently with the same accent color

**Root cause:** `App.css` sets `.appPage { background-color: #3e3e3e }` unconditionally, but `index.css` has a `@media (prefers-color-scheme: light)` block that sets dark navy text and white buttons — producing unreadable text and jarring white buttons on the dark background for users in light mode.

## Test plan

- [ ] Upload flow buttons (Skip, Next, Back, Upload) are styled consistently on the dark background
- [ ] Options page buttons (Browse fields, Download, Upload additional data) are styled correctly
- [ ] Text is readable throughout the upload flow and preview/options pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)