### PR TITLE
fix(metadata): use consistent "number" value token for default variables

### DIFF
--- a/packages/metadata/src/VariablesMap.ts
+++ b/packages/metadata/src/VariablesMap.ts
@@ -76,7 +76,7 @@ export class VariablesMap {
         default: "unknown",
         jsPsych: "The version(s) of the extension(s) used in the trial.",
       },
-      value: "numeric",
+      value: "number",
     };
 
     this.setVariable(extension_version_var);
@@ -109,7 +109,7 @@ export class VariablesMap {
         default: "unknown",
         jsPsych: "The index of the current trial across the whole experiment.",
       },
-      value: "numeric",
+      value: "number",
     };
     this.setVariable(trial_index_var);
 
@@ -121,7 +121,7 @@ export class VariablesMap {
         jsPsych:
           "The number of milliseconds between the start of the experiment and when the trial ended.",
       },
-      value: "numeric",
+      value: "number",
     };
     this.setVariable(time_elapsed_var);
   }

--- a/packages/metadata/tests/metadata-maps.test.ts
+++ b/packages/metadata/tests/metadata-maps.test.ts
@@ -79,7 +79,7 @@ const variable_data: VariableFields[] = [
       default: "unknown",
       jsPsych: "The index of the current trial across the whole experiment.",
     },
-    value: "numeric",
+    value: "number",
   },
   {
     "@type": "PropertyValue",
@@ -89,7 +89,7 @@ const variable_data: VariableFields[] = [
       jsPsych:
         "The number of milliseconds between the start of the experiment and when the trial ended.",
     },
-    value: "numeric",
+    value: "number",
   },
 ];
 


### PR DESCRIPTION
## What

The seeded default variables — `trial_index`, `time_elapsed`, and `extension_version` — were tagged `value: "numeric"` in `VariablesMap.ts`, while every other numeric column gets `value: "number"` from runtime type detection (`typeof`). This meant a single generated `dataset_description.json` could contain **two different tokens for the same concept** (e.g. `trial_index` → `"numeric"` but `rt` → `"number"`).

This aligns the three hard-coded defaults to `"number"`, so numeric columns use one consistent token throughout.

## Why it matters

Surfaced while running a real eye-tracking dataset (38 files, 60k rows) through the library: the output had both `"numeric"` (3 vars) and `"number"` (23 vars). The Psych-DS validator doesn't enforce an enum on `value`, so neither is "invalid", but consumers of the metadata reasonably expect one canonical token for numeric variables.

## Changes

- `packages/metadata/src/VariablesMap.ts` — 3 defaults: `"numeric"` → `"number"`
- `packages/metadata/tests/metadata-maps.test.ts` — updated the 2 fixture assertions to match

## Testing

All 150 tests pass (`npm test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)