### PR TITLE
fix(metadata): register array-element fields in variableMeasured (closes #82)

### DIFF
--- a/.changeset/register-array-element-fields.md
+++ b/.changeset/register-array-element-fields.md
@@ -1,0 +1,6 @@
+---
+"@jspsych/metadata": minor
+"@jspsych/metadata-cli": minor
+---
+
+Register array-of-objects element fields in `variableMeasured` so extracted sidecar CSVs have no undeclared columns. Previously `accumulateArrayColumn` wrote each element's fields as bare columns (e.g. `x`, `y`) plus `element_index` into the extracted-array CSV, but never added them to `variableMeasured`, so Psych-DS validation reported `CSV_COLUMN_MISSING_FROM_METADATA`. Element fields are now emitted under dotted names (`tobii_data.x`, `validation_data.pointData.point`) — avoiding collisions between same-named fields of different array columns — and each is registered with its correct type and min/max/levels tracking. `element_index` is registered once. Object- and array-valued element fields are recorded one level deep (a single dotted JSON column, `value:"object"`/`"array"`); they are not further expanded or extracted. This is the array-side counterpart to the plain-object sidecar fix and completes Psych-DS column/variable round-tripping for nested data.

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -561,7 +561,7 @@ export default class JsPsychMetadata {
           // because typeof [] === "object" in JS).
           await this.generateMetadata(variable, value, pluginType, version);
           this.updateVariable(variable, "value", "array");
-          this.accumulateArrayColumn(variable, value as any[], joinValues);
+          await this.accumulateArrayColumn(variable, value as any[], joinValues, pluginType, version);
         } else {
           await this.generateMetadata(variable, value, pluginType, version);
         }
@@ -791,7 +791,7 @@ export default class JsPsychMetadata {
         // and extract any object elements into a separate CSV.
         await this.generateMetadata(childName, childValue, pluginType, version);
         this.updateVariable(childName, "value", "array");
-        this.accumulateArrayColumn(childName, childValue, joinValues);
+        await this.accumulateArrayColumn(childName, childValue, joinValues, pluginType, version);
       } else {
         await this.generateMetadata(childName, childValue, pluginType, version);
       }
@@ -802,22 +802,83 @@ export default class JsPsychMetadata {
    * Accumulates the object elements of an array column into `extractedArrays` for
    * separate Psych-DS CSV output, keyed by the column's (possibly dotted) name.
    * Each emitted row is the join key values, an `element_index`, then the element's
-   * own fields. Null / primitive elements are skipped; arrays with no object
+   * own fields under DOTTED names (`columnName.field`) so they don't collide with
+   * top-level columns or with fields of other array columns. Every emitted column —
+   * the element fields and `element_index` — is registered in variableMeasured so the
+   * sidecar CSV has no columns missing from the metadata. Element fields are recorded
+   * one level deep: an object- or array-valued field becomes a single dotted column
+   * holding its JSON value (it is not further expanded or extracted).
+   * Null / primitive top-level array elements are skipped; arrays with no object
    * elements produce no rows.
    */
-  private accumulateArrayColumn(columnName: string, arr: any[], joinValues: Record<string, any>) {
-    const hasObjectElements = arr.some(
-      (el) => el !== null && typeof el === "object" && !Array.isArray(el)
-    );
-    if (!hasObjectElements) return;
-
-    const existing = this.extractedArrays.get(columnName) ?? [];
-    arr.forEach((element, elementIndex) => {
+  private async accumulateArrayColumn(columnName: string, arr: any[], joinValues: Record<string, any>, pluginType: string, version: string) {
+    const objectElements: Array<{ element: Record<string, any>; index: number }> = [];
+    arr.forEach((element, index) => {
       if (element !== null && typeof element === "object" && !Array.isArray(element)) {
-        existing.push({ ...joinValues, element_index: elementIndex, ...element });
+        objectElements.push({ element, index });
       }
     });
+    if (objectElements.length === 0) return;
+
+    // element_index is a real column in every extracted-array CSV; declare it once so it
+    // isn't flagged as missing from variableMeasured.
+    if (!this.containsVariable("element_index")) {
+      this.setVariable({
+        "@type": "PropertyValue",
+        name: "element_index",
+        description: { default: "Position of this element within its source array column (0-based)." },
+        value: "number",
+      });
+    }
+
+    const existing = this.extractedArrays.get(columnName) ?? [];
+    for (const { element, index } of objectElements) {
+      const row: Record<string, any> = { ...joinValues, element_index: index };
+      for (const key of Object.keys(element)) {
+        const fieldName = `${columnName}.${key}`;
+        const fieldValue = element[key];
+        row[fieldName] = fieldValue;
+        await this.registerArrayElementField(fieldName, fieldValue, pluginType, version);
+      }
+      existing.push(row);
+    }
     this.extractedArrays.set(columnName, existing);
+  }
+
+  /**
+   * Registers (or folds another value into) one field of an extracted array element under
+   * its dotted name, so every column written to the array sidecar CSV is represented in
+   * variableMeasured. Object/array-valued fields are recorded one level deep — a single
+   * dotted column holding the JSON value — and are not further expanded or extracted.
+   */
+  private async registerArrayElementField(name: string, value: any, pluginType: string, version: string) {
+    // Empty values: ensure the column is declared (placeholder) without polluting min/max/levels.
+    if (value === null || value === undefined || value === "" || value === "null") {
+      if (!this.containsVariable(name)) {
+        this.setVariable({ "@type": "PropertyValue", name, description: { default: "unknown" }, value: "unknown" });
+      }
+      return;
+    }
+
+    const isArray = Array.isArray(value);
+    const type = isArray ? "array" : typeof value;
+    const needsRegister = !this.containsVariable(name) || (this.getVariable(name) as VariableFields).value === "unknown";
+
+    if (needsRegister) {
+      // First real value: register with the plugin description (if any) and correct type,
+      // tracking min/max/levels via generateMetadata's updateFields call.
+      await this.generateMetadata(name, value, pluginType, version);
+      if (!this.containsVariable(name)) {
+        // generateMetadata is a no-op without a pluginType — declare the column anyway.
+        this.setVariable({ "@type": "PropertyValue", name, description: { default: "unknown" }, value: type });
+        this.updateFields(name, value, type);
+      } else if (isArray) {
+        this.updateVariable(name, "value", "array"); // typeof [] === "object"; override
+      }
+    } else {
+      // Already registered: fold this value into min/max/levels without refetching the description.
+      this.updateFields(name, value, type);
+    }
   }
 
   /**

--- a/packages/metadata/tests/metadata-nested-columns.test.ts
+++ b/packages/metadata/tests/metadata-nested-columns.test.ts
@@ -191,8 +191,8 @@ describe("Nested JSON column handling", () => {
       expect(extracted.has("response.samples")).toBe(true);
       const rows = extracted.get("response.samples")!;
       expect(rows).toHaveLength(2);
-      expect(rows[0]).toMatchObject({ trial_index: 0, element_index: 0, x: 1, y: 2 });
-      expect(rows[1]).toMatchObject({ trial_index: 0, element_index: 1, x: 3, y: 4 });
+      expect(rows[0]).toMatchObject({ trial_index: 0, element_index: 0, "response.samples.x": 1, "response.samples.y": 2 });
+      expect(rows[1]).toMatchObject({ trial_index: 0, element_index: 1, "response.samples.x": 3, "response.samples.y": 4 });
     });
 
     test("nested arrays of primitives are typed 'array' but not extracted", async () => {
@@ -247,8 +247,8 @@ describe("Nested JSON column handling", () => {
 
       const rows = arrays.get("mouse_tracking_data")!;
       expect(rows).toHaveLength(2);
-      expect(rows[0]).toMatchObject({ trial_index: 3, element_index: 0, x: 120, y: 340, t: 0 });
-      expect(rows[1]).toMatchObject({ trial_index: 3, element_index: 1, x: 121, y: 338, t: 16 });
+      expect(rows[0]).toMatchObject({ trial_index: 3, element_index: 0, "mouse_tracking_data.x": 120, "mouse_tracking_data.y": 340, "mouse_tracking_data.t": 0 });
+      expect(rows[1]).toMatchObject({ trial_index: 3, element_index: 1, "mouse_tracking_data.x": 121, "mouse_tracking_data.y": 338, "mouse_tracking_data.t": 16 });
     });
 
     test("null elements within an array are skipped without error", async () => {
@@ -260,8 +260,8 @@ describe("Nested JSON column handling", () => {
 
       const rows = meta.getExtractedArrays().get("mouse_tracking_data")!;
       expect(rows).toHaveLength(2);
-      expect(rows[0].x).toBe(1);
-      expect(rows[1].x).toBe(2);
+      expect(rows[0]["mouse_tracking_data.x"]).toBe(1);
+      expect(rows[1]["mouse_tracking_data.x"]).toBe(2);
     });
 
     test("primitive array [1,2,3] falls through to normal handling — no extracted arrays entry", async () => {
@@ -284,9 +284,9 @@ describe("Nested JSON column handling", () => {
 
       const rows = meta.getExtractedArrays().get("mouse_tracking_data")!;
       expect(rows).toHaveLength(3);
-      expect(rows[0]).toMatchObject({ trial_index: 0, element_index: 0, x: 1 });
-      expect(rows[1]).toMatchObject({ trial_index: 1, element_index: 0, x: 2 });
-      expect(rows[2]).toMatchObject({ trial_index: 1, element_index: 1, x: 3 });
+      expect(rows[0]).toMatchObject({ trial_index: 0, element_index: 0, "mouse_tracking_data.x": 1 });
+      expect(rows[1]).toMatchObject({ trial_index: 1, element_index: 0, "mouse_tracking_data.x": 2 });
+      expect(rows[2]).toMatchObject({ trial_index: 1, element_index: 1, "mouse_tracking_data.x": 3 });
     });
 
     test("second generate() call resets extracted arrays — rows from first call are not retained", async () => {
@@ -302,7 +302,7 @@ describe("Nested JSON column handling", () => {
 
       const rows = meta.getExtractedArrays().get("mouse_tracking_data")!;
       expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({ trial_index: 0, element_index: 0, x: 99 });
+      expect(rows[0]).toMatchObject({ trial_index: 0, element_index: 0, "mouse_tracking_data.x": 99 });
     });
   });
 
@@ -475,8 +475,8 @@ describe("generate() arrayJoinKeys option", () => {
 
     const rows = meta.getExtractedArrays().get("mouse_tracking_data")!;
     expect(rows).toHaveLength(4);
-    expect(rows[0]).toMatchObject({ subject_id: "s1", trial_index: 0, element_index: 0, x: 1, y: 2 });
-    expect(rows[2]).toMatchObject({ subject_id: "s2", trial_index: 0, element_index: 0, x: 5, y: 6 });
+    expect(rows[0]).toMatchObject({ subject_id: "s1", trial_index: 0, element_index: 0, "mouse_tracking_data.x": 1, "mouse_tracking_data.y": 2 });
+    expect(rows[2]).toMatchObject({ subject_id: "s2", trial_index: 0, element_index: 0, "mouse_tracking_data.x": 5, "mouse_tracking_data.y": 6 });
   });
 
   test("custom arrayJoinKeys: composite keys are unique across all extracted rows", async () => {
@@ -505,7 +505,7 @@ describe("generate() arrayJoinKeys option", () => {
 
     expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("not unique"));
     const rows = meta.getExtractedArrays().get("mouse_tracking_data")!;
-    expect(rows[0]).toMatchObject({ trial_index: 0, element_index: 0, x: 1 });
+    expect(rows[0]).toMatchObject({ trial_index: 0, element_index: 0, "mouse_tracking_data.x": 1 });
     warnSpy.mockRestore();
   });
 
@@ -663,5 +663,116 @@ describe("plain-object column extraction (getExtractedObjects)", () => {
 
     expect(meta.getExtractedObjects().has("mouse_tracking_data")).toBe(false);
     expect(meta.getExtractedArrays().has("mouse_tracking_data")).toBe(true);
+  });
+});
+
+// ─── array-element field registration (issue #82) ───────────────────────────
+// Array-of-objects columns are extracted to a sidecar CSV. Every column that sidecar
+// carries — the dotted element fields and element_index — must be registered in
+// variableMeasured so it isn't reported as CSV_COLUMN_MISSING_FROM_METADATA. Element
+// fields are recorded one level deep (object/array fields become a single dotted JSON
+// column; not further expanded — tracked separately as a follow-up).
+
+describe("array-element field registration", () => {
+  const mockFetch4 = jest.fn().mockResolvedValue({ text: () => Promise.resolve("") });
+  beforeEach(() => { (global as any).fetch = mockFetch4; mockFetch4.mockClear(); });
+
+  const B = { trial_type: "mock-plugin", trial_index: 0, time_elapsed: 100 };
+
+  test("element fields are registered under dotted names with correct types + min/max", async () => {
+    const data = JSON.stringify([
+      { ...B, gaze: [{ x: 10, y: 5, valid: true }] },
+      { ...B, trial_index: 1, gaze: [{ x: 30, y: 7, valid: false }] },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const names = meta.getVariableNames();
+    expect(names).toContain("gaze.x");
+    expect(names).toContain("gaze.y");
+    expect(names).toContain("gaze.valid");
+
+    const x = meta.getVariable("gaze.x") as any;
+    expect(x.value).toBe("number");
+    expect(x.minValue).toBe(10);
+    expect(x.maxValue).toBe(30);
+    expect((meta.getVariable("gaze.valid") as any).value).toBe("boolean");
+  });
+
+  test("element_index is registered exactly once", async () => {
+    const data = JSON.stringify([
+      { ...B, gaze: [{ x: 1 }], other: [{ y: 2 }] },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    expect(meta.getVariableNames()).toContain("element_index");
+    expect((meta.getVariable("element_index") as any).value).toBe("number");
+    expect(meta.getVariableNames().filter(n => n === "element_index")).toHaveLength(1);
+  });
+
+  test("VALIDATION INVARIANT: every extracted-array sidecar column is in variableMeasured", async () => {
+    const data = JSON.stringify([
+      { ...B, gaze: [{ x: 1, y: 2 }, { x: 3, y: 4 }], clicks: [{ target: "a", correct: true }] },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const declared = new Set(meta.getVariableNames());
+    for (const [, rows] of meta.getExtractedArrays()) {
+      for (const row of rows) {
+        for (const col of Object.keys(row)) {
+          expect(declared.has(col)).toBe(true); // no column missing from variableMeasured
+        }
+      }
+    }
+  });
+
+  test("object/array element fields are recorded one level deep (dotted JSON column, not expanded)", async () => {
+    const data = JSON.stringify([
+      { ...B, pts: [{ point: { x: 1, y: 2 }, samples: [9, 8] }] },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const names = meta.getVariableNames();
+    expect(names).toContain("pts.point");
+    expect(names).toContain("pts.samples");
+    expect((meta.getVariable("pts.point") as any).value).toBe("object");
+    expect((meta.getVariable("pts.samples") as any).value).toBe("array");
+    // not expanded / not extracted further
+    expect(names).not.toContain("pts.point.x");
+    expect(meta.getExtractedArrays().has("pts.samples")).toBe(false);
+
+    // the sidecar row keeps the nested value under the single dotted column
+    const row = meta.getExtractedArrays().get("pts")![0];
+    expect(row["pts.point"]).toEqual({ x: 1, y: 2 });
+    expect(row["pts.samples"]).toEqual([9, 8]);
+  });
+
+  test("element field that is null in all elements is still declared (no phantom column)", async () => {
+    const data = JSON.stringify([
+      { ...B, gaze: [{ x: 1, pupil: null }, { x: 2, pupil: null }] },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    expect(meta.getVariableNames()).toContain("gaze.pupil");
+    // and the sidecar column exists, so the invariant holds
+    const declared = new Set(meta.getVariableNames());
+    for (const row of meta.getExtractedArrays().get("gaze")!) {
+      for (const col of Object.keys(row)) expect(declared.has(col)).toBe(true);
+    }
+  });
+
+  test("dotted names prevent collisions between same-named fields of different array columns", async () => {
+    const data = JSON.stringify([
+      { ...B, gaze: [{ x: 1 }], clicks: [{ x: 999 }] },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    expect((meta.getVariable("gaze.x") as any).minValue).toBe(1);
+    expect((meta.getVariable("clicks.x") as any).minValue).toBe(999);
   });
 });


### PR DESCRIPTION
Closes #82.

## Problem

Array-of-objects columns are extracted into sidecar CSVs (`accumulateArrayColumn` → `extractedArrays`), but the element fields and the synthetic `element_index` were written as **columns** without ever being registered in `variableMeasured`. Psych-DS requires every CSV column to be declared, so the validator reported `CSV_COLUMN_MISSING_FROM_METADATA` — the mirror image of the object-column bug fixed in #83.

## Fix

`accumulateArrayColumn` now:
- Emits element fields under **dotted names** (`tobii_data.x`, `validation_data.pointData.point`) so they don't collide with top-level columns or with same-named fields of other array columns.
- **Registers** each element field in `variableMeasured` with its correct type and `minValue`/`maxValue`/`levels` tracking (register-once, then fold subsequent values in — no redundant description refetch).
- **Registers `element_index` once** as a numeric variable.
- Declares all-`null` element fields too (placeholder), so no column is left undeclared.

**Scope:** object/array-valued element fields are recorded **one level deep** — a single dotted JSON column (`value:"object"`/`"array"`) — and are *not* further expanded or extracted. Deeper recursion inside array elements is intentionally left as a separate follow-up.

No `data.ts` change needed — the CLI writes whatever columns the rows carry.

## Verification

- Updated existing array tests to the dotted column names; added registration + validation-invariant tests (every extracted-array sidecar column is represented in `variableMeasured`). **Full suite 202/202**, stable across runs.
- `psychds-validator` on real fixtures: **full eye-tracking dataset (38 files, 2.1 GB output) → 0 errors** (`CSV_COLUMN_MISSING_FROM_METADATA` eliminated); **event-boundary (145 files) → 0 errors** (no regression).

With this and #83, nested object **and** array columns now round-trip cleanly between `variableMeasured` and the generated CSVs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)