### PR TITLE
feat(metadata): recursively unnest data inside extracted array elements

### DIFF
--- a/.changeset/recurse-array-element-unnesting.md
+++ b/.changeset/recurse-array-element-unnesting.md
@@ -1,0 +1,6 @@
+---
+"@jspsych/metadata": minor
+"@jspsych/metadata-cli": minor
+---
+
+Recursively unnest nested data inside extracted array elements. Previously an array-of-objects column was extracted one level deep, so an element field that was itself an object (`pointData.point`) or an array (`pointData.gazeSamples`) was kept as a single opaque JSON column. Now element fields recurse: a nested plain object is expanded into deeper dotted columns in the same sidecar row (`pointData.point.x`, `pointData.point.y`), and a nested array-of-objects is extracted into its own grandchild CSV (`..._measure-...GazeSamples_data.csv`). Grandchild tables remain joinable to their specific parent element via a qualified `<column>.element_index` key carried alongside the existing join keys (e.g. `trial_index` + `validation_data.pointData.element_index` + the grandchild's own `element_index`), and every such key/column is registered in `variableMeasured`. This completes Psych-DS round-tripping for arbitrarily nested object/array data — arrays nested inside arrays inside objects now fully expand instead of bottoming out as JSON.

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -802,14 +802,17 @@ export default class JsPsychMetadata {
    * Accumulates the object elements of an array column into `extractedArrays` for
    * separate Psych-DS CSV output, keyed by the column's (possibly dotted) name.
    * Each emitted row is the join key values, an `element_index`, then the element's
-   * own fields under DOTTED names (`columnName.field`) so they don't collide with
-   * top-level columns or with fields of other array columns. Every emitted column —
-   * the element fields and `element_index` — is registered in variableMeasured so the
-   * sidecar CSV has no columns missing from the metadata. Element fields are recorded
-   * one level deep: an object- or array-valued field becomes a single dotted column
-   * holding its JSON value (it is not further expanded or extracted).
-   * Null / primitive top-level array elements are skipped; arrays with no object
-   * elements produce no rows.
+   * fields under DOTTED names (`columnName.field`) so they don't collide with top-level
+   * columns or with fields of other array columns. Every emitted column is registered in
+   * variableMeasured so the sidecar CSV has no columns missing from the metadata.
+   *
+   * Element fields recurse (see expandElementFields): a nested plain object is expanded
+   * into deeper dotted columns in the SAME row; a nested array is extracted into its own
+   * grandchild CSV, joinable via `${columnName}.element_index` (this element's position)
+   * carried alongside the existing join keys.
+   *
+   * Null / primitive top-level array elements are skipped; arrays with no object elements
+   * produce no rows.
    */
   private async accumulateArrayColumn(columnName: string, arr: any[], joinValues: Record<string, any>, pluginType: string, version: string) {
     const objectElements: Array<{ element: Record<string, any>; index: number }> = [];
@@ -820,8 +823,10 @@ export default class JsPsychMetadata {
     });
     if (objectElements.length === 0) return;
 
-    // element_index is a real column in every extracted-array CSV; declare it once so it
-    // isn't flagged as missing from variableMeasured.
+    // Declare the join-key columns this table carries that aren't known yet: element_index, plus
+    // any ancestor element-index keys passed down from an enclosing array (qualified
+    // "<col>.element_index"). Pre-existing keys (trial_index, participant_id, …) are already
+    // declared and are skipped.
     if (!this.containsVariable("element_index")) {
       this.setVariable({
         "@type": "PropertyValue",
@@ -830,29 +835,73 @@ export default class JsPsychMetadata {
         value: "number",
       });
     }
+    for (const joinKey of Object.keys(joinValues)) {
+      if (!this.containsVariable(joinKey)) {
+        this.setVariable({
+          "@type": "PropertyValue",
+          name: joinKey,
+          description: { default: "Join key referencing the position of an enclosing array element (0-based index)." },
+          value: "number",
+        });
+      }
+    }
 
     const existing = this.extractedArrays.get(columnName) ?? [];
     for (const { element, index } of objectElements) {
       const row: Record<string, any> = { ...joinValues, element_index: index };
-      for (const key of Object.keys(element)) {
-        const fieldName = `${columnName}.${key}`;
-        const fieldValue = element[key];
-        row[fieldName] = fieldValue;
-        await this.registerArrayElementField(fieldName, fieldValue, pluginType, version);
-      }
+      // Join keys for any array nested inside this element: the current keys plus THIS element's
+      // index, qualified by the column name so it doesn't clash with the grandchild's own
+      // element_index. This keeps a grandchild sub-table joinable to its specific parent element.
+      const nestedJoin: Record<string, any> = { ...joinValues, [`${columnName}.element_index`]: index };
+      await this.expandElementFields(columnName, element, row, nestedJoin, pluginType, version);
       existing.push(row);
     }
     this.extractedArrays.set(columnName, existing);
   }
 
   /**
-   * Registers (or folds another value into) one field of an extracted array element under
-   * its dotted name, so every column written to the array sidecar CSV is represented in
-   * variableMeasured. Object/array-valued fields are recorded one level deep — a single
-   * dotted column holding the JSON value — and are not further expanded or extracted.
+   * Recursively records one array element's fields into `row` under dotted names. Scalars become
+   * columns with type + min/max/levels tracking; nested plain objects are expanded into the SAME
+   * row (deeper dotted columns); nested arrays are extracted into their own grandchild CSV via
+   * accumulateArrayColumn (keyed by `nestedJoin`). Object/array nodes are also kept as a single
+   * dotted JSON column so their own name is represented as a column too.
    */
-  private async registerArrayElementField(name: string, value: any, pluginType: string, version: string) {
-    // Empty values: ensure the column is declared (placeholder) without polluting min/max/levels.
+  private async expandElementFields(prefix: string, obj: Record<string, any>, row: Record<string, any>, nestedJoin: Record<string, any>, pluginType: string, version: string) {
+    for (const key of Object.keys(obj)) {
+      const name = `${prefix}.${key}`;
+      const value = obj[key];
+      row[name] = value; // object/array values are JSON-stringified at CSV-write time
+
+      if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+        await this.registerNodeVariable(name, value, "object", pluginType, version);
+        await this.expandElementFields(name, value, row, nestedJoin, pluginType, version);
+      } else if (Array.isArray(value)) {
+        await this.registerNodeVariable(name, value, "array", pluginType, version);
+        await this.accumulateArrayColumn(name, value, nestedJoin, pluginType, version);
+      } else {
+        await this.registerScalarField(name, value, pluginType, version);
+      }
+    }
+  }
+
+  /** Registers an object/array node variable once (with its plugin description, if any). */
+  private async registerNodeVariable(name: string, value: any, type: "object" | "array", pluginType: string, version: string) {
+    if (this.containsVariable(name) && (this.getVariable(name) as VariableFields).value !== "unknown") return;
+    await this.generateMetadata(name, value, pluginType, version);
+    if (!this.containsVariable(name)) {
+      // generateMetadata is a no-op without a pluginType — declare the column anyway.
+      this.setVariable({ "@type": "PropertyValue", name, description: { default: "unknown" }, value: type });
+    } else {
+      this.updateVariable(name, "value", type); // typeof {}/[] === "object"; pin the intended type
+    }
+  }
+
+  /**
+   * Registers one scalar array-element field under its dotted name (so the sidecar column is
+   * represented in variableMeasured), then folds later values into min/max/levels. Empty values
+   * still declare the column (placeholder) without polluting min/max/levels.
+   */
+  private async registerScalarField(name: string, value: any, pluginType: string, version: string) {
     if (value === null || value === undefined || value === "" || value === "null") {
       if (!this.containsVariable(name)) {
         this.setVariable({ "@type": "PropertyValue", name, description: { default: "unknown" }, value: "unknown" });
@@ -860,23 +909,16 @@ export default class JsPsychMetadata {
       return;
     }
 
-    const isArray = Array.isArray(value);
-    const type = isArray ? "array" : typeof value;
+    const type = typeof value;
     const needsRegister = !this.containsVariable(name) || (this.getVariable(name) as VariableFields).value === "unknown";
 
     if (needsRegister) {
-      // First real value: register with the plugin description (if any) and correct type,
-      // tracking min/max/levels via generateMetadata's updateFields call.
       await this.generateMetadata(name, value, pluginType, version);
       if (!this.containsVariable(name)) {
-        // generateMetadata is a no-op without a pluginType — declare the column anyway.
         this.setVariable({ "@type": "PropertyValue", name, description: { default: "unknown" }, value: type });
         this.updateFields(name, value, type);
-      } else if (isArray) {
-        this.updateVariable(name, "value", "array"); // typeof [] === "object"; override
       }
     } else {
-      // Already registered: fold this value into min/max/levels without refetching the description.
       this.updateFields(name, value, type);
     }
   }

--- a/packages/metadata/tests/metadata-nested-columns.test.ts
+++ b/packages/metadata/tests/metadata-nested-columns.test.ts
@@ -728,7 +728,7 @@ describe("array-element field registration", () => {
     }
   });
 
-  test("object/array element fields are recorded one level deep (dotted JSON column, not expanded)", async () => {
+  test("object element field is expanded; primitive-array element field stays a JSON column", async () => {
     const data = JSON.stringify([
       { ...B, pts: [{ point: { x: 1, y: 2 }, samples: [9, 8] }] },
     ]);
@@ -737,16 +737,20 @@ describe("array-element field registration", () => {
 
     const names = meta.getVariableNames();
     expect(names).toContain("pts.point");
-    expect(names).toContain("pts.samples");
     expect((meta.getVariable("pts.point") as any).value).toBe("object");
+    // object field IS now expanded (recursive follow-up)
+    expect(names).toContain("pts.point.x");
+    expect(names).toContain("pts.point.y");
+
+    // primitive array (no object elements) is NOT extracted — kept as a single JSON column
+    expect(names).toContain("pts.samples");
     expect((meta.getVariable("pts.samples") as any).value).toBe("array");
-    // not expanded / not extracted further
-    expect(names).not.toContain("pts.point.x");
     expect(meta.getExtractedArrays().has("pts.samples")).toBe(false);
 
-    // the sidecar row keeps the nested value under the single dotted column
     const row = meta.getExtractedArrays().get("pts")![0];
-    expect(row["pts.point"]).toEqual({ x: 1, y: 2 });
+    expect(row["pts.point.x"]).toBe(1);
+    expect(row["pts.point.y"]).toBe(2);
+    expect(row["pts.point"]).toEqual({ x: 1, y: 2 }); // node kept as JSON column too
     expect(row["pts.samples"]).toEqual([9, 8]);
   });
 
@@ -774,5 +778,96 @@ describe("array-element field registration", () => {
 
     expect((meta.getVariable("gaze.x") as any).minValue).toBe(1);
     expect((meta.getVariable("clicks.x") as any).minValue).toBe(999);
+  });
+});
+
+// ─── recursive array-element unnesting (deeper levels) ──────────────────────
+// Building on the one-level array-element registration: object fields inside an array
+// element are expanded into the same row (deeper dotted columns); array fields inside an
+// array element are extracted to a grandchild table, joinable to their specific parent
+// element via a qualified `<col>.element_index` key.
+
+describe("recursive array-element unnesting", () => {
+  const mf = jest.fn().mockResolvedValue({ text: () => Promise.resolve("") });
+  beforeEach(() => { (global as any).fetch = mf; mf.mockClear(); });
+  const B = { trial_type: "mock-plugin", trial_index: 0, time_elapsed: 100 };
+
+  test("object inside an array element is expanded into the same row (deeper dotted columns)", async () => {
+    const data = JSON.stringify([
+      { ...B, pts: [{ accuracy: 0.9, point: { x: 1, y: 2 } }] },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const names = meta.getVariableNames();
+    expect(names).toContain("pts.point");      // intermediate node
+    expect(names).toContain("pts.point.x");    // expanded leaf
+    expect(names).toContain("pts.point.y");
+    expect((meta.getVariable("pts.point.x") as any).value).toBe("number");
+
+    const row = meta.getExtractedArrays().get("pts")![0];
+    expect(row["pts.point.x"]).toBe(1);
+    expect(row["pts.point.y"]).toBe(2);
+    expect(meta.getExtractedArrays().has("pts.point")).toBe(false); // plain object → no grandchild table
+  });
+
+  test("array inside an array element is extracted to a grandchild table joinable to its parent element", async () => {
+    const data = JSON.stringify([
+      { ...B, pts: [
+        { samples: [{ t: 0, v: 9 }, { t: 1, v: 8 }] },
+        { samples: [{ t: 0, v: 7 }] },
+      ] },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const gc = meta.getExtractedArrays().get("pts.samples")!;
+    expect(gc).toBeDefined();
+    expect(gc).toHaveLength(3);
+    // multi-level join key: trial_index + qualified parent index + own element_index
+    expect(gc[0]).toMatchObject({ trial_index: 0, "pts.element_index": 0, element_index: 0, "pts.samples.t": 0, "pts.samples.v": 9 });
+    expect(gc[1]).toMatchObject({ trial_index: 0, "pts.element_index": 0, element_index: 1, "pts.samples.v": 8 });
+    expect(gc[2]).toMatchObject({ trial_index: 0, "pts.element_index": 1, element_index: 0, "pts.samples.v": 7 });
+
+    expect(meta.getVariableNames()).toContain("pts.element_index"); // qualified parent-index key declared
+    expect(meta.getVariableNames()).toContain("pts.samples");       // array parent node declared
+    expect((meta.getVariable("pts.samples") as any).value).toBe("array");
+  });
+
+  test("VALIDATION INVARIANT holds across parent AND grandchild tables", async () => {
+    const data = JSON.stringify([
+      { ...B, pts: [{ accuracy: 0.9, samples: [{ t: 0, v: 1 }] }] },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const declared = new Set(meta.getVariableNames());
+    for (const [, rows] of meta.getExtractedArrays()) {
+      for (const row of rows) {
+        for (const col of Object.keys(row)) expect(declared.has(col)).toBe(true);
+      }
+    }
+  });
+
+  test("three levels deep: array → element-array → element-array", async () => {
+    const data = JSON.stringify([
+      { ...B, a: [{ b: [{ c: [{ leaf: 1 }] }] }] },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const ggc = meta.getExtractedArrays().get("a.b.c")!;
+    expect(ggc).toBeDefined();
+    expect(ggc[0]).toMatchObject({
+      trial_index: 0,
+      "a.element_index": 0,
+      "a.b.element_index": 0,
+      element_index: 0,
+      "a.b.c.leaf": 1,
+    });
+    const declared = new Set(meta.getVariableNames());
+    for (const [, rows] of meta.getExtractedArrays())
+      for (const row of rows)
+        for (const col of Object.keys(row)) expect(declared.has(col)).toBe(true);
   });
 });


### PR DESCRIPTION
**Stacked on #84** (base = `fix/array-element-fields-variablemeasured`; will retarget to `main` once #84 merges).

## Problem
Array-of-objects columns were extracted only one level deep, so an element field that was itself an object (`validation_data.pointData.point`) or an array (`validation_data.pointData.gazeSamples`) stayed an opaque JSON column.

## Fix
`accumulateArrayColumn` now recurses via `expandElementFields`:
- **object inside an element** → expanded into deeper dotted columns in the *same* sidecar row (`pointData.point.x`, `pointData.point.y`).
- **array inside an element** → extracted into its own **grandchild CSV**, joinable to its specific parent element via a qualified `<column>.element_index` key carried alongside the existing join keys (e.g. `trial_index` + `validation_data.pointData.element_index` + the grandchild's own `element_index`).
- Every key/column (including the qualified parent-index keys) is registered in `variableMeasured`; scalars keep type + min/max/levels tracking. Composes to arbitrary depth.

## Verification
- New tests incl. object-in-element, array-in-element (grandchild + multi-level join key), 3-levels-deep, and validation invariant across parent + grandchild tables. **Full suite 206/206.**
- **Real CLI binary on the full eye-tracking dataset (38 files):** produces `...GazeSamples` grandchild tables and validates with **0 errors**; **event-boundary** still 0 errors.

## Out of scope (separate follow-up)
Arrays of **primitives** (`block_order:[16,100,4,1]`, `images:[…]`) are still recorded as a single `value:"array"` column with no per-element breakdown (issue #72 §3). Handled next, on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)