### PR TITLE
fix(metadata): no levels for boolean variables; keep string true/false as levels

### DIFF
--- a/.changeset/boolean-no-levels.md
+++ b/.changeset/boolean-no-levels.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata": patch
+---
+
+Boolean variables no longer record `levels`. Genuine boolean values (`typeof === "boolean"`) are typed `value:"boolean"` with no `levels`/`minValue`/`maxValue`, and string `"true"`/`"false"` values are kept as strings so they surface as `levels: ["true","false"]` (no longer coerced to boolean). A manual `value:"boolean"` override now drops any detected levels and warns when the detected values don't map cleanly to true/false (anything other than `true`/`false`/`0`/`1`). This also fixes a bug where raw booleans were pushed into the `levels` array, producing inconsistent `[false]`/empty output.

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -528,9 +528,10 @@ export default class JsPsychMetadata {
         if (value.trim() !== "" && Number.isFinite(asNumber)) {
           type = "number";
           value = asNumber;
-        } else if (value.toLowerCase() === "true" || value.toLowerCase() === "false") {
-          type = "boolean";
-          value = (value.toLowerCase() === "true");
+          // NOTE: "true"/"false" strings are intentionally left as strings (not coerced to
+          // boolean) so they accumulate as levels ["true","false"]. Only genuine booleans
+          // (typeof value === "boolean", e.g. from JSON data) are typed "boolean", and those
+          // get no levels — see updateFields.
         } else if (value.startsWith("{") || value.startsWith("[")) {
           const parsed = tryParseJSON(value);
           if (parsed !== null) {
@@ -636,6 +637,11 @@ export default class JsPsychMetadata {
    * @param {*} type - The type of the datapoint
    */
   private updateFields(variable, value, type) {
+    // Boolean variables are self-describing through value:"boolean" — true/false carry no
+    // additional information as levels, so we record no levels (or min/max) for them. This also
+    // avoids pushing raw booleans into the levels array (which is meant to hold strings).
+    if (type === "boolean") return;
+
     // getVariable returns this.variables[name] || {}, so always an object — "x" in {} is safe.
     // The returned value is a live reference to the stored object; mutations (delete below) take
     // effect immediately. If getVariable is ever changed to return a defensive copy, the delete
@@ -736,6 +742,11 @@ export default class JsPsychMetadata {
         for (const parameter in variable_parameters) {
           const parameter_value = variable_parameters[parameter];
           this.updateVariable(variable_key, parameter, parameter_value);
+          // A user-chosen value:"boolean" override warns if the detected values aren't boolean-like
+          // and drops any detected levels/min/max (booleans carry none — see updateFields).
+          if (parameter === "value" && parameter_value === "boolean") {
+            this.applyBooleanOverride(variable_key);
+          }
           if (parameter === "name") variable_key = parameter_value; // renames future instances if changing name
         }
       }
@@ -754,6 +765,43 @@ export default class JsPsychMetadata {
         this.setAuthor(author);
       }
     } else this.setMetadataField(key, value);
+  }
+
+  /**
+   * Applies a user-chosen `value:"boolean"` override to an already-populated variable.
+   * Warns when the values detected from the data don't map cleanly to boolean logic
+   * (anything other than true/false/0/1, case-insensitive), then drops the detected
+   * levels/min/max so the variable matches how genuine booleans are recorded (no levels).
+   */
+  private applyBooleanOverride(variableName: string) {
+    // getVariable returns the live stored object, so the deletes below take effect in place
+    // (same pattern as updateFields).
+    const existing = this.getVariable(variableName) as VariableFields;
+
+    const isBooleanLike = (v: unknown): boolean => {
+      const s = String(v).trim().toLowerCase();
+      return s === "true" || s === "false" || s === "0" || s === "1";
+    };
+
+    const offenders = new Set<string>();
+    if (Array.isArray(existing.levels)) {
+      for (const level of existing.levels) if (!isBooleanLike(level)) offenders.add(String(level));
+    }
+    if (typeof existing.minValue === "number" && !isBooleanLike(existing.minValue)) offenders.add(String(existing.minValue));
+    if (typeof existing.maxValue === "number" && !isBooleanLike(existing.maxValue)) offenders.add(String(existing.maxValue));
+
+    if (offenders.size > 0) {
+      const sample = [...offenders].slice(0, 10).join(", ");
+      const more = offenders.size > 10 ? `, …(+${offenders.size - 10} more)` : "";
+      console.warn(
+        `Variable "${variableName}" was set to value:"boolean", but the detected values don't map cleanly to true/false: ${sample}${more}. Double-check this is the intended type.`
+      );
+    }
+
+    // Booleans carry no levels/min/max; drop any detected so the override is consistent.
+    delete existing.levels;
+    delete existing.minValue;
+    delete existing.maxValue;
   }
 
   /**

--- a/packages/metadata/tests/metadata-module.test.ts
+++ b/packages/metadata/tests/metadata-module.test.ts
@@ -626,3 +626,89 @@ describe("mixed-type column handling (#71)", () => {
     expect(col.maxValue).toBeUndefined();
   });
 });
+
+describe("boolean vs string true/false levels", () => {
+  let jsPsychMetadata: JsPsychMetadata;
+
+  beforeEach(() => {
+    jsPsychMetadata = new JsPsychMetadata();
+  });
+
+  const col = (m: JsPsychMetadata, name: string) =>
+    (m.getMetadata()["variableMeasured"] as any[]).find((v) => v.name === name);
+
+  test("genuine boolean values get value:boolean and NO levels", async () => {
+    // JSON data carries real booleans (typeof === "boolean").
+    const data = JSON.stringify([
+      { trial_type: "html-keyboard-response", correct: true },
+      { trial_type: "html-keyboard-response", correct: false },
+    ]);
+
+    await jsPsychMetadata.generate(data);
+
+    const c = col(jsPsychMetadata, "correct");
+    expect(c).toBeDefined();
+    expect(c.value).toBe("boolean");
+    expect(c.levels).toBeUndefined();
+    expect(c.minValue).toBeUndefined();
+    expect(c.maxValue).toBeUndefined();
+  });
+
+  test('string "true"/"false" stay string and surface as levels (both values)', async () => {
+    // CSV cells are strings; "true"/"false" are not coerced to boolean, so they accumulate
+    // as levels — and both values are captured (regression for the missing-"true" / [false] bug).
+    const csv = [
+      "trial_type,flag",
+      "html-keyboard-response,true",
+      "html-keyboard-response,false",
+      "html-keyboard-response,true",
+    ].join("\n");
+
+    await jsPsychMetadata.generate(csv, {}, "csv");
+
+    const c = col(jsPsychMetadata, "flag");
+    expect(c).toBeDefined();
+    expect(c.value).toBe("string");
+    expect(new Set(c.levels)).toEqual(new Set(["true", "false"]));
+  });
+
+  test("manual value:boolean override drops detected levels", async () => {
+    const csv = ["trial_type,flag", "t,true", "t,false"].join("\n");
+    await jsPsychMetadata.generate(csv, {}, "csv");
+    expect(col(jsPsychMetadata, "flag").levels).toBeDefined();
+
+    await jsPsychMetadata.updateMetadata({ variables: { flag: { value: "boolean" } } });
+
+    const c = col(jsPsychMetadata, "flag");
+    expect(c.value).toBe("boolean");
+    expect(c.levels).toBeUndefined();
+  });
+
+  test("manual value:boolean override warns when data isn't boolean-like", async () => {
+    const csv = ["trial_type,block", "t,Practice", "t,Bonus"].join("\n");
+    await jsPsychMetadata.generate(csv, {}, "csv");
+
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await jsPsychMetadata.updateMetadata({ variables: { block: { value: "boolean" } } });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Variable "block"'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("Practice"));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("manual value:boolean override does NOT warn for true/false/0/1 data", async () => {
+    const csv = ["trial_type,flag", "t,1", "t,0"].join("\n");
+    await jsPsychMetadata.generate(csv, {}, "csv");
+
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await jsPsychMetadata.updateMetadata({ variables: { flag: { value: "boolean" } } });
+      const booleanWarnings = warn.mock.calls.filter((c) => String(c[0]).includes('value:"boolean"'));
+      expect(booleanWarnings).toHaveLength(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Booleans no longer carry `levels`, and string `"true"`/`"false"` values are kept as strings so they surface as levels. Behavior is keyed off the value's actual type (source format — CSV vs JSON — doesn't matter).

## Changes
- **Genuine boolean** (`typeof === "boolean"`, e.g. from JSON) → `value:"boolean"` with **no** `levels`/`minValue`/`maxValue` (`updateFields` early-returns for boolean).
- **String `"true"`/`"false"`** → no longer coerced to boolean; they stay a string column and surface as `levels: ["true","false"]`.
- **Manual `value:"boolean"` override** (via options / `updateMetadata`) → drops any detected levels and **warns** when the detected values don't map cleanly to true/false (anything other than `true`/`false`/`0`/`1`, case-insensitive).

## Bug fixed
`VariablesMap.updateLevels` was pushing **raw booleans** into the `levels` array (its own comment says levels should be strings; `added_value.length` is `undefined` for a boolean). That fragile path produced the inconsistent `[false]` / missing-`true` / empty-levels output. Routing booleans away from `levels` removes it at the source.

## Behavior change to note
CSV columns of `"true"`/`"false"` that were previously typed `value:"boolean"` are now `value:"string"` with `levels: ["true","false"]` — the direct consequence of "if it's a string, show true/false."

## Tests
Adds regression tests (boolean → no levels; string true/false → levels; override drops levels; override warns on non-boolean-like data; override stays quiet for `true/false/0/1`). **Full suite: 216 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)