### PR TITLE
feat(frontend): in-browser Psych-DS validation on Review step

### DIFF
--- a/.changeset/frontend-in-browser-validation.md
+++ b/.changeset/frontend-in-browser-validation.md
@@ -1,0 +1,5 @@
+---
+"frontend": minor
+---
+
+Add in-browser Psych-DS validation to the Review step. A "Validate dataset" button runs the official `psychds-validator` web bundle directly in the browser against the generated `dataset_description.json` and the uploaded data files, showing a pass/error/warning report inline instead of only pointing users to the CLI. The validator bundle is code-split and lazy-loaded on first use, and the command-line instructions remain available as a fallback.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15147,11 +15147,14 @@
       "version": "0.0.2",
       "dependencies": {
         "@jspsych/metadata": "^0.0.3",
+        "jsonld": "^8.3.2",
         "jszip": "^3.10.1",
+        "psychds-validator": "^1.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@types/node": "^20.0.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.15.0",
@@ -15532,6 +15535,16 @@
         "node": ">=12"
       }
     },
+    "packages/frontend/node_modules/@types/node": {
+      "version": "20.19.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
+      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "packages/frontend/node_modules/@vitejs/plugin-react-swc": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.0.tgz",
@@ -15581,6 +15594,13 @@
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
       }
+    },
+    "packages/frontend/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/frontend/node_modules/vite": {
       "version": "5.3.5",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -11,11 +11,14 @@
   },
   "dependencies": {
     "@jspsych/metadata": "^0.0.3",
+    "jsonld": "^8.3.2",
     "jszip": "^3.10.1",
+    "psychds-validator": "^1.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@types/node": "^20.0.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.15.0",

--- a/packages/frontend/src/datasetLayout.ts
+++ b/packages/frontend/src/datasetLayout.ts
@@ -1,0 +1,16 @@
+// Shared knowledge about how a Psych-DS dataset is laid out, used by both the
+// Review download (zip) and the in-browser validator so the two never drift.
+
+/** Canonical Psych-DS metadata filename. */
+export const DATASET_DESCRIPTION_FILENAME = 'dataset_description.json';
+
+/**
+ * Maps an uploaded file's original path to its place in the dataset layout:
+ * strips the top-level export folder and nests it under `data/`
+ * (e.g. "my-experiment/sub01.csv" -> "data/sub01.csv").
+ */
+export function dataFilePath(originalPath: string): string {
+  const parts = originalPath.split('/');
+  const relative = parts.length > 1 ? parts.slice(1).join('/') : originalPath;
+  return `data/${relative}`;
+}

--- a/packages/frontend/src/pages/Review.module.css
+++ b/packages/frontend/src/pages/Review.module.css
@@ -136,3 +136,135 @@
 .cliBlock:last-child {
   margin-bottom: 0;
 }
+
+/* In-browser validation */
+
+.validateBtn {
+  align-self: flex-start;
+  background: none;
+  border: 1px solid var(--c-accent);
+  border-radius: 7px;
+  padding: 0.5em 1.4em;
+  font-size: 0.88rem;
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--c-accent);
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s, opacity 0.15s;
+}
+
+.validateBtn:hover:not(:disabled) {
+  background-color: var(--c-accent);
+  color: #ffffff;
+}
+
+.validateBtn:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.resultBanner {
+  margin-top: 0.85rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-size: 0.86rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.resultValid {
+  color: var(--c-success-text);
+  background: var(--c-success-bg);
+  border-color: var(--c-success-border);
+}
+
+.resultInvalid {
+  color: var(--c-danger);
+  background: var(--c-danger-bg);
+  border-color: var(--c-danger-border);
+}
+
+.resultUnavailable {
+  color: var(--c-warn-text);
+  background: var(--c-warn-bg);
+  border-color: var(--c-warn-border);
+  font-weight: 500;
+}
+
+.issueGroupLabel {
+  margin: 0.85rem 0 0.4rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--c-ink-3);
+}
+
+.issueList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.issueItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: 5px;
+  background: var(--c-danger-bg);
+  border-left: 3px solid var(--c-danger);
+}
+
+.issueItem.issueWarn {
+  background: var(--c-warn-bg);
+  border-left-color: var(--c-warn-icon);
+}
+
+.issueKey {
+  font-family: 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--c-ink);
+}
+
+.issueReason {
+  font-size: 0.83rem;
+  color: var(--c-ink-2);
+  line-height: 1.45;
+}
+
+.issueEvidence {
+  margin-top: 0.3rem;
+  padding: 0.3rem 0.5rem;
+  border-radius: 4px;
+  background: var(--c-border-sub);
+  font-family: 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.76rem;
+  color: var(--c-ink);
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.cliAlt {
+  margin-top: 1rem;
+  border-top: 1px solid var(--c-border);
+  padding-top: 0.85rem;
+}
+
+.cliAltSummary {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--c-ink-3);
+  cursor: pointer;
+  margin-bottom: 0.6rem;
+}
+
+.cliAltSummary:hover {
+  color: var(--c-ink-2);
+}

--- a/packages/frontend/src/pages/Review.tsx
+++ b/packages/frontend/src/pages/Review.tsx
@@ -3,6 +3,7 @@ import JSZip from 'jszip';
 import JsPsychMetadata from '@jspsych/metadata';
 import JsonViewer from '../components/JsonViewer';
 import PageHeader from '../components/PageHeader';
+import { DATASET_DESCRIPTION_FILENAME as FILENAME, dataFilePath } from '../datasetLayout';
 import type { PsychDSValidationResult } from '../validation/validatePsychDS';
 import styles from './Review.module.css';
 
@@ -10,8 +11,6 @@ interface ReviewProps {
   jsPsychMetadata: JsPsychMetadata;
   dataFiles?: Map<string, { content: string; type: string }>;
 }
-
-const FILENAME = 'dataset_description.json';
 
 function blobDownload(blob: Blob, filename: string) {
   const url = URL.createObjectURL(blob);
@@ -22,13 +21,6 @@ function blobDownload(blob: Blob, filename: string) {
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
-}
-
-function dataFilePath(originalPath: string): string {
-  // Strip the top-level folder (e.g. "my-experiment/sub01.csv" → "data/sub01.csv")
-  const parts = originalPath.split('/');
-  const relative = parts.length > 1 ? parts.slice(1).join('/') : originalPath;
-  return `data/${relative}`;
 }
 
 type ValidationStatus = 'idle' | 'running' | 'done' | 'unavailable';

--- a/packages/frontend/src/pages/Review.tsx
+++ b/packages/frontend/src/pages/Review.tsx
@@ -3,6 +3,7 @@ import JSZip from 'jszip';
 import JsPsychMetadata from '@jspsych/metadata';
 import JsonViewer from '../components/JsonViewer';
 import PageHeader from '../components/PageHeader';
+import type { PsychDSValidationResult } from '../validation/validatePsychDS';
 import styles from './Review.module.css';
 
 interface ReviewProps {
@@ -30,9 +31,14 @@ function dataFilePath(originalPath: string): string {
   return `data/${relative}`;
 }
 
+type ValidationStatus = 'idle' | 'running' | 'done' | 'unavailable';
+
 const Review: React.FC<ReviewProps> = ({ jsPsychMetadata, dataFiles }) => {
   const [downloaded, setDownloaded] = useState(false);
   const [zipped, setZipped] = useState(false);
+  const [valStatus, setValStatus] = useState<ValidationStatus>('idle');
+  const [valResult, setValResult] = useState<PsychDSValidationResult | null>(null);
+  const [valError, setValError] = useState<string | null>(null);
 
   // Review is unmounted whenever the user navigates away, so each visit gets a fresh snapshot.
   const metadataObj = useMemo(() => jsPsychMetadata.getMetadata(), []);
@@ -90,6 +96,26 @@ const Review: React.FC<ReviewProps> = ({ jsPsychMetadata, dataFiles }) => {
     setZipped(true);
   };
 
+  const handleValidate = async () => {
+    setValStatus('running');
+    setValError(null);
+    try {
+      // Lazy-loaded so the ~260 KB validator bundle stays out of the initial load.
+      const { validatePsychDS } = await import('../validation/validatePsychDS');
+      const result = await validatePsychDS(metadataJson, zipEligibleFiles);
+      setValResult(result);
+      setValStatus('done');
+    } catch (err) {
+      setValResult(null);
+      setValError(
+        err instanceof Error && err.name === 'ValidationUnavailableError'
+          ? err.message
+          : `Validation failed unexpectedly: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      setValStatus('unavailable');
+    }
+  };
+
   const usesFilePicker = 'showSaveFilePicker' in window;
 
   return (
@@ -145,13 +171,87 @@ const Review: React.FC<ReviewProps> = ({ jsPsychMetadata, dataFiles }) => {
       <div className={styles.validatorNote}>
         <p className={styles.validatorTitle}>Validate your dataset</p>
         <p className={styles.validatorText}>
-          Once <code className={styles.code}>dataset_description.json</code> is in your dataset folder, run the validator from the command line:
+          Check this metadata{hasDataFiles ? ' and your data files' : ''} against the
+          Psych-DS standard right here. Validation runs in your browser and needs an
+          internet connection to fetch the schema.
         </p>
-        <pre className={styles.cliBlock}>npx @jspsych/cli validate</pre>
-        <p className={styles.validatorText}>
-          Or with a specific path:
-        </p>
-        <pre className={styles.cliBlock}>npx @jspsych/cli validate --psych-ds-dir ./your-dataset</pre>
+
+        <button
+          className={styles.validateBtn}
+          onClick={handleValidate}
+          disabled={valStatus === 'running'}
+        >
+          {valStatus === 'running'
+            ? 'Validating…'
+            : valStatus === 'idle'
+              ? 'Validate dataset'
+              : 'Re-validate'}
+        </button>
+
+        {valStatus === 'unavailable' && valError && (
+          <div className={`${styles.resultBanner} ${styles.resultUnavailable}`}>
+            {valError}
+          </div>
+        )}
+
+        {valStatus === 'done' && valResult && (
+          <>
+            <div
+              className={`${styles.resultBanner} ${
+                valResult.valid ? styles.resultValid : styles.resultInvalid
+              }`}
+            >
+              {valResult.valid
+                ? '✓ Valid Psych-DS dataset'
+                : `✗ ${valResult.errors.length} error${valResult.errors.length !== 1 ? 's' : ''} found`}
+              {valResult.warnings.length > 0 &&
+                ` · ${valResult.warnings.length} warning${valResult.warnings.length !== 1 ? 's' : ''}`}
+            </div>
+
+            {valResult.errors.length > 0 && (
+              <>
+                <p className={styles.issueGroupLabel}>Errors</p>
+                <ul className={styles.issueList}>
+                  {valResult.errors.map((issue, i) => (
+                    <li key={`e${i}`} className={styles.issueItem}>
+                      <span className={styles.issueKey}>{issue.key}</span>
+                      <span className={styles.issueReason}>{issue.reason}</span>
+                      {issue.evidence.map((ev, j) => (
+                        <span key={j} className={styles.issueEvidence}>{ev}</span>
+                      ))}
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+
+            {valResult.warnings.length > 0 && (
+              <>
+                <p className={styles.issueGroupLabel}>Warnings</p>
+                <ul className={styles.issueList}>
+                  {valResult.warnings.map((issue, i) => (
+                    <li key={`w${i}`} className={`${styles.issueItem} ${styles.issueWarn}`}>
+                      <span className={styles.issueKey}>{issue.key}</span>
+                      <span className={styles.issueReason}>{issue.reason}</span>
+                      {issue.evidence.map((ev, j) => (
+                        <span key={j} className={styles.issueEvidence}>{ev}</span>
+                      ))}
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+          </>
+        )}
+
+        <details className={styles.cliAlt}>
+          <summary className={styles.cliAltSummary}>Prefer the command line?</summary>
+          <p className={styles.validatorText}>
+            Once <code className={styles.code}>dataset_description.json</code> is in your dataset folder, run:
+          </p>
+          <pre className={styles.cliBlock}>npx @jspsych/cli validate</pre>
+          <pre className={styles.cliBlock}>npx @jspsych/cli validate --psych-ds-dir ./your-dataset</pre>
+        </details>
       </div>
     </div>
     </>

--- a/packages/frontend/src/validation/node-stub.ts
+++ b/packages/frontend/src/validation/node-stub.ts
@@ -1,0 +1,10 @@
+// Stub for Node-only modules pulled in by psychds-validator's web bundle.
+//
+// The browser bundle (psychds-validator/web/psychds-validator.js) statically
+// imports `node:process` and dynamically imports winston / chalk / cli-table3 /
+// node:fs inside `if (!isBrowser)` branches that never run in the browser.
+// Rollup/esbuild still has to resolve every specifier at build time, so we alias
+// them all to this empty module (see vite.config.ts). The only property the
+// bundle reads is `process.versions` — left undefined here so its `isNode`
+// check evaluates to false and the browser code path is taken.
+export default {};

--- a/packages/frontend/src/validation/psychds-validator-web.d.ts
+++ b/packages/frontend/src/validation/psychds-validator-web.d.ts
@@ -1,0 +1,35 @@
+// jsonld ships no type declarations; we only use its default export as an opaque
+// value to hand to the validator via window.jsonld.
+declare module 'jsonld';
+
+// The psychds-validator package only ships types for its Node entry point.
+// Its browser bundle (validateWeb) is untyped, so we describe the slice we use.
+declare module 'psychds-validator/web/psychds-validator.js' {
+  /** A single validation issue as surfaced by the validator. */
+  export interface PsychDSIssue {
+    key: string;
+    severity: 'error' | 'warning' | string;
+    reason: string;
+    files: Map<string, { evidence?: string }>;
+  }
+
+  export interface PsychDSValidationOutput {
+    valid: boolean;
+    /** Iterable of [key, issue] entries. */
+    issues: Iterable<[string, PsychDSIssue]> & { get(key: string): PsychDSIssue | undefined };
+    summary: unknown;
+  }
+
+  /** A node in the in-memory file tree handed to the validator. */
+  export type WebFileNode =
+    | { type: 'file'; file: Blob }
+    | { type: 'directory'; contents: WebFileTree };
+  export interface WebFileTree {
+    [name: string]: WebFileNode;
+  }
+
+  export function validateWeb(
+    fileTree: WebFileTree,
+    options?: Record<string, unknown>,
+  ): Promise<PsychDSValidationOutput>;
+}

--- a/packages/frontend/src/validation/validatePsychDS.ts
+++ b/packages/frontend/src/validation/validatePsychDS.ts
@@ -2,9 +2,9 @@ import jsonld from 'jsonld';
 import {
   validateWeb,
   type WebFileTree,
+  type PsychDSValidationOutput,
 } from 'psychds-validator/web/psychds-validator.js';
-
-const FILENAME = 'dataset_description.json';
+import { DATASET_DESCRIPTION_FILENAME as FILENAME, dataFilePath } from '../datasetLayout';
 
 export interface ValidationIssue {
   key: string;
@@ -35,17 +35,6 @@ export class ValidationUnavailableError extends Error {
 function ensureJsonldGlobal() {
   const w = window as unknown as { jsonld?: unknown };
   if (!w.jsonld) w.jsonld = jsonld;
-}
-
-/**
- * Mirrors Review's zip layout: dataset_description.json at the root and every
- * data file under a `data/` directory, with the top-level export folder
- * stripped (e.g. "my-experiment/sub01.csv" -> "data/sub01.csv").
- */
-function dataFilePath(originalPath: string): string {
-  const parts = originalPath.split('/');
-  const relative = parts.length > 1 ? parts.slice(1).join('/') : originalPath;
-  return `data/${relative}`;
 }
 
 /** Inserts a `/`-separated path into the nested file-tree dict, creating dirs. */
@@ -97,8 +86,12 @@ export async function validatePsychDS(
 
   const tree = buildFileTree(metadataJson, dataFiles);
 
-  let output;
+  let output: PsychDSValidationOutput;
   try {
+    // 'latest' (rather than a pinned version) keeps results consistent with the
+    // CLI (`npx @jspsych/cli validate`) and the deployed web validator, which
+    // both use latest; pinning also risks requesting a schema version the
+    // schema server doesn't have, which would break validation outright.
     output = await validateWeb(tree, { schema: 'latest' });
   } catch (err) {
     console.error('Psych-DS validation could not run:', err);

--- a/packages/frontend/src/validation/validatePsychDS.ts
+++ b/packages/frontend/src/validation/validatePsychDS.ts
@@ -1,0 +1,129 @@
+import jsonld from 'jsonld';
+import {
+  validateWeb,
+  type WebFileTree,
+} from 'psychds-validator/web/psychds-validator.js';
+
+const FILENAME = 'dataset_description.json';
+
+export interface ValidationIssue {
+  key: string;
+  reason: string;
+  /** Per-file detail from the validator (e.g. the specific column names at fault). */
+  evidence: string[];
+}
+
+export interface PsychDSValidationResult {
+  valid: boolean;
+  errors: ValidationIssue[];
+  warnings: ValidationIssue[];
+}
+
+/** Thrown when validation can't run at all (e.g. the schema can't be fetched). */
+export class ValidationUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationUnavailableError';
+  }
+}
+
+/**
+ * The validator's browser path expects jsonld as a global (`window.jsonld`),
+ * mirroring how the deployed Psych-DS validator loads it. The npm package's
+ * `browser` field makes this the browser build under Vite.
+ */
+function ensureJsonldGlobal() {
+  const w = window as unknown as { jsonld?: unknown };
+  if (!w.jsonld) w.jsonld = jsonld;
+}
+
+/**
+ * Mirrors Review's zip layout: dataset_description.json at the root and every
+ * data file under a `data/` directory, with the top-level export folder
+ * stripped (e.g. "my-experiment/sub01.csv" -> "data/sub01.csv").
+ */
+function dataFilePath(originalPath: string): string {
+  const parts = originalPath.split('/');
+  const relative = parts.length > 1 ? parts.slice(1).join('/') : originalPath;
+  return `data/${relative}`;
+}
+
+/** Inserts a `/`-separated path into the nested file-tree dict, creating dirs. */
+function insertFile(tree: WebFileTree, path: string, content: string) {
+  const segments = path.split('/').filter(Boolean);
+  const filename = segments.pop();
+  if (!filename) return;
+
+  let dir = tree;
+  for (const segment of segments) {
+    let node = dir[segment];
+    if (!node || node.type !== 'directory') {
+      node = { type: 'directory', contents: {} };
+      dir[segment] = node;
+    }
+    dir = node.contents;
+  }
+  dir[filename] = { type: 'file', file: new Blob([content]) };
+}
+
+function buildFileTree(
+  metadataJson: string,
+  dataFiles?: Map<string, string>,
+): WebFileTree {
+  const tree: WebFileTree = {
+    [FILENAME]: { type: 'file', file: new Blob([metadataJson]) },
+  };
+  if (dataFiles) {
+    for (const [originalPath, content] of dataFiles) {
+      insertFile(tree, dataFilePath(originalPath), content);
+    }
+  }
+  return tree;
+}
+
+/**
+ * Runs the Psych-DS validator entirely in the browser against the generated
+ * metadata plus the user's data files. Requires network access — the validator
+ * fetches the Psych-DS schema and schema.org context at runtime.
+ *
+ * @param metadataJson  Serialized dataset_description.json.
+ * @param dataFiles     Map of original file path -> text content (CSV/JSON).
+ */
+export async function validatePsychDS(
+  metadataJson: string,
+  dataFiles?: Map<string, string>,
+): Promise<PsychDSValidationResult> {
+  ensureJsonldGlobal();
+
+  const tree = buildFileTree(metadataJson, dataFiles);
+
+  let output;
+  try {
+    output = await validateWeb(tree, { schema: 'latest' });
+  } catch (err) {
+    console.error('Psych-DS validation could not run:', err);
+    throw new ValidationUnavailableError(
+      'The validator could not run. It needs an internet connection to fetch ' +
+        'the Psych-DS schema — check your connection and try again.',
+    );
+  }
+
+  const errors: ValidationIssue[] = [];
+  const warnings: ValidationIssue[] = [];
+  for (const [, issue] of output.issues) {
+    // Each issue carries per-file evidence (e.g. the exact offending column
+    // names) — dedupe and keep it so the UI can show what actually failed.
+    const evidence = [
+      ...new Set(
+        [...issue.files.values()]
+          .map((file) => file?.evidence?.trim())
+          .filter((e): e is string => Boolean(e)),
+      ),
+    ];
+    const entry: ValidationIssue = { key: issue.key, reason: issue.reason, evidence };
+    if (issue.severity === 'error') errors.push(entry);
+    else if (issue.severity === 'warning') warnings.push(entry);
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/packages/frontend/src/validation/validatePsychDS.ts
+++ b/packages/frontend/src/validation/validatePsychDS.ts
@@ -95,9 +95,14 @@ export async function validatePsychDS(
     output = await validateWeb(tree, { schema: 'latest' });
   } catch (err) {
     console.error('Psych-DS validation could not run:', err);
+    // The overwhelmingly common cause is no network access — the validator fetches
+    // the Psych-DS schema and schema.org context at runtime. Lead with that, but
+    // include the underlying error so a genuine validator/internal failure isn't
+    // silently misreported as a connectivity problem.
+    const detail = err instanceof Error ? err.message : String(err);
     throw new ValidationUnavailableError(
       'The validator could not run. It needs an internet connection to fetch ' +
-        'the Psych-DS schema — check your connection and try again.',
+        `the Psych-DS schema — check your connection and try again. (Details: ${detail})`,
     );
   }
 

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,7 +1,41 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+
+const require = createRequire(import.meta.url)
+
+// psychds-validator's browser bundle statically imports `node:process` and
+// dynamically imports a few Node-only modules inside `if (!isBrowser)` branches
+// that never execute in the browser. Point them all at an empty stub so the
+// bundle resolves. See src/validation/node-stub.ts for details.
+const nodeStub = fileURLToPath(new URL('./src/validation/node-stub.ts', import.meta.url))
+
+// The package's `exports` map only exposes ".", so a deep import to
+// ./web/psychds-validator.js is blocked by Node/Rollup exports resolution.
+// Resolve the real file by absolute path (works regardless of npm hoisting)
+// and alias the specifier to it, which bypasses exports resolution.
+const validatorMain = require.resolve('psychds-validator')
+const PKG = 'psychds-validator'
+const validatorWeb = path.join(
+  validatorMain.slice(0, validatorMain.lastIndexOf(PKG) + PKG.length),
+  'web',
+  'psychds-validator.js',
+)
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      'psychds-validator/web/psychds-validator.js': validatorWeb,
+      'node:process': nodeStub,
+      'node:fs/promises': nodeStub,
+      'node:fs': nodeStub,
+      winston: nodeStub,
+      chalk: nodeStub,
+      'cli-table3': nodeStub,
+    },
+  },
 })


### PR DESCRIPTION
## What

Replaces the "run the CLI to validate" instructions on the **Review** step with a **Validate dataset** button that runs the official `psychds-validator` browser bundle (`validateWeb`) directly in the browser — against the generated `dataset_description.json` plus the uploaded data files — and renders a pass / error / warning report inline. Each issue surfaces the validator's per-file **evidence** (e.g. the exact offending column names).

Validation produces identical results to `npx @jspsych/cli validate`, since it uses the same validator code.

Closes #3

## Why

The frontend wizard previously ended by telling users to drop the file in a folder and run the CLI. Validating in-browser closes the loop so users get immediate, actionable feedback before they ever leave the page.

## How

The validator package ships a browser bundle (`psychds-validator/web/psychds-validator.js`) exporting `validateWeb(fileTree, options)`, which takes an in-memory file tree instead of reading from disk. Two integration wrinkles, both handled in `vite.config.ts`:

- The bundle is ESM with a top-level `import process from "node:process"` plus Node-only dynamic imports (`winston`, `chalk`, `cli-table3`, `node:fs`) guarded by `isBrowser`. These are aliased to an empty stub (`src/validation/node-stub.ts`) since they never run in the browser.
- The deep `web/` import is blocked by the package's `exports` map (only `"."` is exposed), so it's aliased to the real file path resolved via `require.resolve`.

The browser path expects `jsonld` as a global (`window.jsonld`), set from the npm `jsonld` package (its `browser` field resolves the browser build under Vite). The validator chunk is **code-split and lazy-loaded** on first Validate click, so it stays out of the initial bundle (~234 KB). The CLI instructions remain available as a collapsible fallback.

## Notes for reviewers

- **No fork of the validator was needed** — we use the published browser bundle directly. The only fragility is importing by an internal path (the web build isn't in the package's official `exports`); a small upstream PR to expose it would remove that.
- Validation **requires network access** (the validator fetches the Psych-DS schema and schema.org context at runtime); the UI shows a clear "needs internet" state when it can't run.
- The validator surfaces genuine CSV/JSON mismatches **by design**: `variableMeasured` is generated from all uploaded data, but Psych-DS only validates CSV columns, so variables that live only in `.json` files are reported as `VARIABLE_MISSING_FROM_CSV_COLUMNS`. This ties into the separate `json-to-csv-conversion` effort.

## Base branch

Stacked on `feat/frontend-redesign` (#85), which adds the Review step this builds on. Once #85 merges, this will auto-retarget to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)