### PR TITLE
refactor: move Psych-DS utils from CLI to core metadata package

### DIFF
--- a/.changeset/metadata-shared-utils.md
+++ b/.changeset/metadata-shared-utils.md
@@ -1,0 +1,7 @@
+---
+"@jspsych/metadata": minor
+---
+
+Export Psych-DS utility functions from the core package: `isValidPsychDSDataFilename`, `toPsychDSValue`, `deriveArrayFilename`, `objectsToCSV`, `disambiguateArrayFilename`. Previously these lived only in the CLI. Moving them to core makes them available to any downstream consumer (e.g. the frontend) and ensures the CLI and any future tools share a single implementation.
+
+The CLI now imports these functions from `@jspsych/metadata` instead of defining them locally. No behaviour change.

--- a/packages/cli/src/data.ts
+++ b/packages/cli/src/data.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
-import JsPsychMetadata, { analyzeJoinKeys, JoinKeyAnalysis, parseCSV } from "@jspsych/metadata";
-import { expandHomeDir, deriveArrayFilename, disambiguateArrayFilename, disambiguateFilename, objectsToCSV, fileStem, isValidPsychDSDataFilename } from "./utils";
+import JsPsychMetadata, { analyzeJoinKeys, JoinKeyAnalysis, parseCSV, deriveArrayFilename, disambiguateArrayFilename, objectsToCSV, isValidPsychDSDataFilename } from "@jspsych/metadata";
+import { expandHomeDir, disambiguateFilename, fileStem } from "./utils";
 
 export interface GenerateOptions {
   arrayJoinKeys?: string[];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,12 +3,12 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { input, select, checkbox, Separator } from '@inquirer/prompts';
-import JsPsychMetadata, { analyzeJoinKeys, JoinKeyAnalysis } from "@jspsych/metadata";
+import JsPsychMetadata, { analyzeJoinKeys, JoinKeyAnalysis, isValidPsychDSDataFilename, toPsychDSValue } from "@jspsych/metadata";
 import path from 'path';
 import { processDirectory, processOptions, saveTextToPath, loadMetadata, preAnalyzeDirectory, enumerateDataFiles } from "./data";
 import { validateDirectory, validateJson, validatePsychDS } from './validatefunctions';
 import { createDirectoryWithStructure } from './handlefiles';
-import { isValidPsychDSDataFilename, toPsychDSValue, fileStem } from './utils';
+import { fileStem } from './utils';
 
 // Define a type for the parsed arguments
 interface Argv {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -10,108 +10,12 @@ export function expandHomeDir(directoryPath: string): string {
 }
 
 /**
- * Full Psych-DS data filename pattern, mirroring psychds-validator's fileRegex:
- * one or more `keyword-value` pairs (keyword: lowercase letters only; value:
- * alphanumeric, any case) joined by `_`, ending in `_data.csv` (or `.tsv`).
- * Anything else fails validation with a FILENAME_KEYWORD_FORMATTING_ERROR.
- */
-const PSYCH_DS_FILENAME_RE = /^([a-z]+-[a-zA-Z0-9]+)(_[a-z]+-[a-zA-Z0-9]+)*_data\.(csv|tsv)$/;
-
-/** True if `name` is a fully Psych-DS-compliant data filename. */
-export function isValidPsychDSDataFilename(name: string): boolean {
-  return PSYCH_DS_FILENAME_RE.test(name);
-}
-
-/**
- * Coerces an arbitrary string into a Psych-DS *value* segment ([a-zA-Z0-9]+).
- * Psych-DS values forbid hyphens and underscores, so every run of non-alphanumeric
- * characters is treated as a word boundary, removed, and the following word
- * capitalised — yielding camelCase so meaning survives:
- *   "mouse_tracking" → "mouseTracking", "subject1" → "subject1", "RT (ms)" → "RTMs".
- * Returns `fallback` when the input has no alphanumeric characters.
- */
-export function toPsychDSValue(name: string, fallback = 'value'): string {
-  const parts = name.split(/[^a-zA-Z0-9]+/).filter(Boolean);
-  if (parts.length === 0) return fallback;
-  return parts[0] + parts.slice(1).map((p) => p[0].toUpperCase() + p.slice(1)).join('');
-}
-
-/**
  * The "stem" of a source file: its basename minus the extension and a trailing `_data`.
  * For an already-compliant file this is its Psych-DS base (the keyword-value sequence):
  *   "subject-1_data.csv" → "subject-1",  "experiment.json" → "experiment".
  */
 export function fileStem(file: string): string {
   return path.basename(file, path.extname(file)).replace(/_data$/i, '');
-}
-
-/**
- * Derives the Psych-DS filename for an extracted-array CSV from its parent file's
- * already-normalized base plus the column name:
- *   base "subject-subject1" + column "mouse_tracking"
- *     → "subject-subject1_measure-mouseTracking_data.csv"
- * "measure" is an unofficial Psych-DS keyword: it triggers a validator *warning*
- * (not an error), used because no official keyword describes a per-column sub-table.
- */
-export function deriveArrayFilename(parentBase: string, columnName: string): string {
-  return `${parentBase}_measure-${toPsychDSValue(columnName, 'col')}_data.csv`;
-}
-
-/**
- * Serialises an array of objects to RFC 4180 CSV. Nested objects/arrays in a cell
- * are serialised as JSON strings so no data is lost.
- * trial_index and element_index columns are placed first; remaining columns
- * follow in the order they first appear across all rows.
- */
-export function objectsToCSV(rows: Array<Record<string, any>>, priorityCols: string[] = ['trial_index', 'element_index']): string {
-  if (rows.length === 0) return '';
-
-  const allKeys = new Set<string>();
-  for (const row of rows) {
-    for (const key of Object.keys(row)) allKeys.add(key);
-  }
-  const otherCols = [...allKeys].filter(k => !priorityCols.includes(k));
-  const headers = [...priorityCols.filter(c => allKeys.has(c)), ...otherCols];
-
-  const escape = (val: any): string => {
-    if (val === null || val === undefined) return '';
-    // Preserve nested objects/arrays as JSON strings so no data is lost.
-    // (String(val) would collapse them to "[object Object]".)
-    const str = typeof val === 'object' ? JSON.stringify(val) : String(val);
-    return str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')
-      ? `"${str.replace(/"/g, '""')}"` : str;
-  };
-
-  const lines = [headers.join(',')];
-  for (const row of rows) {
-    lines.push(headers.map(h => escape(row[h])).join(','));
-  }
-  return lines.join('\r\n');
-}
-
-/**
- * Returns a filename not already present in `used`. If `base` is free it is returned
- * as-is; otherwise a counter is appended directly to the final value
- * (e.g. foo_measure-bar_data.csv → foo_measure-bar2_data.csv) until a free name is found.
- *
- * The counter is appended with no separator on purpose: a hyphen or underscore would
- * split into an extra/invalid keyword-value pair and fail the Psych-DS filename regex
- * (values must be [a-zA-Z0-9]+). Distinct source files / columns can normalize to the
- * same name (camelCase coercion is lossy, and only the basename is used), and since all
- * outputs land in one flat directory this prevents one from silently overwriting another.
- */
-export function disambiguateArrayFilename(base: string, used: Set<string>): string {
-  if (!used.has(base)) return base;
-
-  const suffix = '_data.csv';
-  const root = base.endsWith(suffix) ? base.slice(0, -suffix.length) : base.replace(/\.csv$/i, '');
-  let n = 2;
-  let candidate = `${root}${n}${suffix}`;
-  while (used.has(candidate)) {
-    n += 1;
-    candidate = `${root}${n}${suffix}`;
-  }
-  return candidate;
 }
 
 /**

--- a/packages/cli/tests/utils.test.ts
+++ b/packages/cli/tests/utils.test.ts
@@ -1,13 +1,9 @@
 import os from "os";
 import path from "path";
+import { objectsToCSV, isValidPsychDSDataFilename, toPsychDSValue, deriveArrayFilename, disambiguateArrayFilename } from "@jspsych/metadata";
 import {
   expandHomeDir,
-  objectsToCSV,
-  isValidPsychDSDataFilename,
-  toPsychDSValue,
   fileStem,
-  deriveArrayFilename,
-  disambiguateArrayFilename,
   disambiguateFilename,
 } from "../src/utils";
 import { generatePath } from "../src/data";

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -960,5 +960,5 @@ export {
   AuthorFields,
   VariableFields
 }
-export { analyzeJoinKeys, parseCSV } from "./utils";
+export { analyzeJoinKeys, parseCSV, isValidPsychDSDataFilename, toPsychDSValue, deriveArrayFilename, objectsToCSV, disambiguateArrayFilename } from "./utils";
 export type { JoinKeyAnalysis } from "./utils";

--- a/packages/metadata/src/utils.ts
+++ b/packages/metadata/src/utils.ts
@@ -185,6 +185,92 @@ export function analyzeJoinKeys(
   };
 }
 
+/**
+ * Full Psych-DS data filename pattern: one or more `keyword-value` pairs
+ * (keyword: lowercase letters; value: alphanumeric, any case) joined by `_`,
+ * ending in `_data.csv` (or `.tsv`).
+ */
+const PSYCH_DS_FILENAME_RE = /^([a-z]+-[a-zA-Z0-9]+)(_[a-z]+-[a-zA-Z0-9]+)*_data\.(csv|tsv)$/;
+
+/** True if `name` is a fully Psych-DS-compliant data filename. */
+export function isValidPsychDSDataFilename(name: string): boolean {
+  return PSYCH_DS_FILENAME_RE.test(name);
+}
+
+/**
+ * Coerces an arbitrary string into a Psych-DS *value* segment ([a-zA-Z0-9]+).
+ * Runs of non-alphanumeric characters are treated as word boundaries: removed
+ * and the next word capitalised, yielding camelCase so meaning is preserved
+ * (e.g. "mouse_tracking" → "mouseTracking", "RT (ms)" → "RTMs").
+ * Returns `fallback` when the input has no alphanumeric characters.
+ */
+export function toPsychDSValue(name: string, fallback = 'value'): string {
+  const parts = name.split(/[^a-zA-Z0-9]+/).filter(Boolean);
+  if (parts.length === 0) return fallback;
+  return parts[0] + parts.slice(1).map((p) => p[0].toUpperCase() + p.slice(1)).join('');
+}
+
+/**
+ * Derives the Psych-DS filename for an extracted-array CSV from its parent
+ * file's already-normalized base plus the column name:
+ *   base "subject-subject1" + column "mouse_tracking"
+ *     → "subject-subject1_measure-mouseTracking_data.csv"
+ */
+export function deriveArrayFilename(parentBase: string, columnName: string): string {
+  return `${parentBase}_measure-${toPsychDSValue(columnName, 'col')}_data.csv`;
+}
+
+/**
+ * Serialises an array of objects to RFC 4180 CSV. Nested objects/arrays in a
+ * cell are serialised as JSON strings so no data is lost. Priority columns
+ * (trial_index, element_index by default) are placed first; remaining columns
+ * follow in the order they first appear across all rows.
+ */
+export function objectsToCSV(rows: Array<Record<string, any>>, priorityCols: string[] = ['trial_index', 'element_index']): string {
+  if (rows.length === 0) return '';
+
+  const allKeys = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) allKeys.add(key);
+  }
+  const otherCols = [...allKeys].filter(k => !priorityCols.includes(k));
+  const headers = [...priorityCols.filter(c => allKeys.has(c)), ...otherCols];
+
+  const escape = (val: any): string => {
+    if (val === null || val === undefined) return '';
+    const str = typeof val === 'object' ? JSON.stringify(val) : String(val);
+    return str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')
+      ? `"${str.replace(/"/g, '""')}"` : str;
+  };
+
+  const lines = [headers.join(',')];
+  for (const row of rows) {
+    lines.push(headers.map(h => escape(row[h])).join(','));
+  }
+  return lines.join('\r\n');
+}
+
+/**
+ * Returns a filename not already present in `used`. If `base` is free it is
+ * returned as-is; otherwise a counter is appended before the `_data.csv`
+ * suffix (e.g. foo_measure-bar_data.csv → foo_measure-bar2_data.csv) until a
+ * free name is found. The counter has no separator — a hyphen or underscore
+ * would create an invalid Psych-DS keyword-value pair.
+ */
+export function disambiguateArrayFilename(base: string, used: Set<string>): string {
+  if (!used.has(base)) return base;
+
+  const suffix = '_data.csv';
+  const root = base.endsWith(suffix) ? base.slice(0, -suffix.length) : base.replace(/\.csv$/i, '');
+  let n = 2;
+  let candidate = `${root}${n}${suffix}`;
+  while (used.has(candidate)) {
+    n += 1;
+    candidate = `${root}${n}${suffix}`;
+  }
+  return candidate;
+}
+
 export async function parseCSV(input) {
   if (!parse) {
     throw new Error('Parser module not loaded');


### PR DESCRIPTION
## Summary

- Moves five pure, platform-independent utility functions out of `packages/cli/src/utils.ts` and into `packages/metadata/src/utils.ts`, where they are now part of the public `@jspsych/metadata` API
- Functions moved: `isValidPsychDSDataFilename`, `toPsychDSValue`, `deriveArrayFilename`, `objectsToCSV`, `disambiguateArrayFilename`
- CLI imports these from `@jspsych/metadata` instead of defining them locally — no behaviour change
- Node-specific helpers (`expandHomeDir`, `fileStem`, `disambiguateFilename`) remain in the CLI since they depend on `os`/`path`

## Motivation

These functions encode Psych-DS domain knowledge (filename patterns, value coercion, RFC 4180 CSV serialisation) that is not inherently CLI-only. Making them part of the core package means any downstream consumer — most immediately the frontend once PR #85 merges — can use them without reaching into CLI internals or duplicating the logic.

## Not included (deferred)

- **Frontend adoption**: the frontend (`packages/frontend`) doesn't currently need these utilities, but can now import them directly from `@jspsych/metadata` once PR #85 (`feat/frontend-redesign`) merges.
- **`parseMissingFields`** in `cli/src/validatefunctions.ts`: kept in CLI — it's brittle regex against validator output strings and has no immediate frontend use case.
- **`disambiguateFilename`**: kept in CLI — uses `path.extname` (Node-only) and only applies to raw file preservation under `data/raw/`.

## Test plan

- [ ] `packages/cli` tests: `npm test` — 88/89 pass (1 pre-existing Windows path failure in `validatefunctions.test.ts` unrelated to this PR)
- [ ] `packages/metadata` build: `npm run build` — clean
- [ ] CLI test file `tests/utils.test.ts` updated to import moved functions from `@jspsych/metadata`

🤖 Generated with [Claude Code](https://claude.com/claude-code)