### PR TITLE
test(frontend): add Jest test suite mirroring the CLI package's setup

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,3 +1,3 @@
 module.exports = {
-  projects: ["packages/metadata", "packages/cli"],
+  projects: ["packages/metadata", "packages/cli", "packages/frontend"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,13 @@
         "jest": "^29.7.0"
       }
     },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -4326,6 +4333,130 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
@@ -4335,6 +4466,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4447,6 +4585,17 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/jsdom": {
@@ -5022,6 +5171,16 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-back": {
@@ -6124,6 +6283,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssfontparser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
@@ -6263,6 +6429,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
@@ -6323,6 +6499,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -8259,6 +8442,13 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true,
+      "license": "(Apache-2.0 OR MPL-1.1)"
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -8419,6 +8609,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ieee754": {
@@ -11284,6 +11487,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -11402,6 +11615,16 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -12588,6 +12811,30 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reduce-extract": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
@@ -13397,6 +13644,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -14774,17 +15034,6 @@
         "jest": "^29.7.0"
       }
     },
-    "packages/cli/node_modules/@types/jest": {
-      "version": "29.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
-      }
-    },
     "packages/cli/node_modules/@types/node": {
       "version": "20.19.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
@@ -14813,6 +15062,12 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@sucrase/jest-plugin": "^3.0.0",
+        "@testing-library/dom": "^10.4.0",
+        "@testing-library/jest-dom": "^6.4.8",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.5.2",
+        "@types/jest": "^29.5.12",
         "@types/node": "^20.0.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -14822,6 +15077,9 @@
         "eslint": "^8.57.0",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.7",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
         "typescript": "^5.2.2",
         "vite": "^5.3.4"
       }
@@ -15329,17 +15587,6 @@
         "husky": "^9.0.11",
         "ts-jest": "^29.1.4",
         "typescript": "^5.5.4"
-      }
-    },
-    "packages/metadata/node_modules/@types/jest": {
-      "version": "29.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
       }
     }
   }

--- a/packages/frontend/jest.config.cjs
+++ b/packages/frontend/jest.config.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+  transform: { "\\.(js|jsx|ts|tsx)$": ["@sucrase/jest-plugin", { jsxRuntime: "automatic" }] },
+  testEnvironment: "jsdom",
+  displayName: { name: "frontend", color: "magentaBright" },
+  setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
+  moduleNameMapper: {
+    // CSS modules resolve to a proxy where styles.foo === "foo", so class names are assertable.
+    "\\.module\\.css$": "identity-obj-proxy",
+    "\\.css$": "<rootDir>/tests/__mocks__/styleMock.cjs",
+    "\\.svg$": "<rootDir>/tests/__mocks__/fileMock.cjs",
+    // The validator's web bundle is browser-only (and hidden behind the package's
+    // exports map), so tests always run against a mock.
+    "^psychds-validator/web/psychds-validator\\.js$":
+      "<rootDir>/tests/__mocks__/psychds-validator-web.ts",
+    "^jsonld$": "<rootDir>/tests/__mocks__/jsonld.ts",
+    // Resolve the workspace library from source so tests don't require a prior build,
+    // mirroring how packages/metadata's own tests import from src.
+    "^@jspsych/metadata$": "<rootDir>/../metadata/src/index.ts",
+  },
+};

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@jspsych/metadata": "^0.0.3",
@@ -18,6 +19,12 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@sucrase/jest-plugin": "^3.0.0",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.4.8",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jest": "^29.5.12",
     "@types/node": "^20.0.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
@@ -27,6 +34,9 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "typescript": "^5.2.2",
     "vite": "^5.3.4"
   }

--- a/packages/frontend/tests/App.test.tsx
+++ b/packages/frontend/tests/App.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "../src/App";
+
+// App's job is routing between Landing and the wizard — stub the wizard shell
+// so this stays a unit test of that flow.
+jest.mock("../src/components/AppShell", () => ({
+  __esModule: true,
+  default: ({ onStartOver }: { onStartOver: () => void }) => (
+    <div>
+      <p>app shell</p>
+      <button onClick={onStartOver}>Start over</button>
+    </div>
+  ),
+}));
+
+describe("App", () => {
+  test("shows the landing page first", () => {
+    render(<App />);
+    expect(screen.getByText("jsPsych Metadata Generator")).toBeInTheDocument();
+    expect(screen.queryByText("app shell")).not.toBeInTheDocument();
+  });
+
+  test("starting a new project enters the wizard", async () => {
+    render(<App />);
+    await userEvent.click(screen.getByText("Create new project"));
+    expect(screen.getByText("app shell")).toBeInTheDocument();
+  });
+
+  test("start over returns to the landing page", async () => {
+    render(<App />);
+    await userEvent.click(screen.getByText("Create new project"));
+    await userEvent.click(screen.getByText("Start over"));
+    expect(screen.getByText("jsPsych Metadata Generator")).toBeInTheDocument();
+  });
+
+  test("theme toggle switches between light and dark", async () => {
+    render(<App />);
+    const toggle = screen.getByRole("button", { name: /Dark/ });
+
+    await userEvent.click(toggle);
+    expect(toggle).toHaveTextContent("Light");
+    expect(localStorage.getItem("theme")).toBe("dark");
+  });
+});

--- a/packages/frontend/tests/Landing.test.tsx
+++ b/packages/frontend/tests/Landing.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Landing from "../src/pages/Landing";
+
+describe("Landing", () => {
+  test("renders the title and both project cards", () => {
+    render(<Landing onStart={jest.fn()} />);
+    expect(screen.getByText("jsPsych Metadata Generator")).toBeInTheDocument();
+    expect(screen.getByText("Create new project")).toBeInTheDocument();
+    expect(screen.getByText("Open existing project")).toBeInTheDocument();
+  });
+
+  test("'Create new project' starts a fresh project", async () => {
+    const onStart = jest.fn();
+    render(<Landing onStart={onStart} />);
+    await userEvent.click(screen.getByText("Create new project"));
+    expect(onStart).toHaveBeenCalledWith(true);
+  });
+
+  test("uploading a dataset_description.json opens an existing project", () => {
+    const onStart = jest.fn();
+    const { container } = render(<Landing onStart={onStart} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['{"name":"test"}'], "dataset_description.json", {
+      type: "application/json",
+    });
+
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(onStart).toHaveBeenCalledWith(false, file);
+  });
+
+  test("does not start when the file dialog is dismissed without a file", () => {
+    const onStart = jest.fn();
+    const { container } = render(<Landing onStart={onStart} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { files: [] } });
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  test("'What is Psych-DS?' expands and collapses the explainer", async () => {
+    render(<Landing onStart={jest.fn()} />);
+    const toggle = screen.getByRole("button", { name: /What is Psych-DS\?/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText(/open standard/)).not.toBeInTheDocument();
+
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/open standard/)).toBeInTheDocument();
+
+    await userEvent.click(toggle);
+    expect(screen.queryByText(/open standard/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/frontend/tests/Review.test.tsx
+++ b/packages/frontend/tests/Review.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import JsPsychMetadata from "@jspsych/metadata";
+import Review from "../src/pages/Review";
+import { validatePsychDS } from "../src/validation/validatePsychDS";
+
+// Review lazy-loads the validator wrapper on the first Validate click; mock it
+// so tests exercise the UI states without the real (network-bound) validator.
+jest.mock("../src/validation/validatePsychDS", () => ({
+  validatePsychDS: jest.fn(),
+}));
+
+const mockValidate = validatePsychDS as jest.Mock;
+
+function makeMetadata(name = "my-project") {
+  const metadata = new JsPsychMetadata();
+  metadata.setMetadataField("name", name);
+  return metadata;
+}
+
+beforeEach(() => {
+  mockValidate.mockReset();
+  (URL.createObjectURL as jest.Mock).mockClear();
+});
+
+describe("Review", () => {
+  test("renders the generated metadata", () => {
+    render(<Review jsPsychMetadata={makeMetadata()} />);
+    // "name" recurs inside variableMeasured entries, so just assert it appears.
+    expect(screen.getAllByText('"name"').length).toBeGreaterThan(0);
+    expect(screen.getByText('"my-project"')).toBeInTheDocument();
+  });
+
+  test("offers only the single-file save when there are no data files", () => {
+    render(<Review jsPsychMetadata={makeMetadata()} />);
+    expect(
+      screen.getByRole("button", { name: "Save dataset_description.json" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /\.zip/ })).not.toBeInTheDocument();
+  });
+
+  test("offers a zip download named after the project when data files exist", () => {
+    const dataFiles = new Map([
+      ["my-experiment/sub01.csv", { content: "a,b\n1,2", type: "csv" }],
+    ]);
+    render(<Review jsPsychMetadata={makeMetadata()} dataFiles={dataFiles} />);
+    expect(
+      screen.getByRole("button", { name: "Download my-project.zip" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Save dataset_description.json only" }),
+    ).toBeInTheDocument();
+  });
+
+  test("ignores non-CSV/JSON files and uploaded dataset_description.json for the zip", () => {
+    const dataFiles = new Map([
+      ["my-experiment/notes.txt", { content: "notes", type: "txt" }],
+      ["my-experiment/dataset_description.json", { content: "{}", type: "json" }],
+    ]);
+    render(<Review jsPsychMetadata={makeMetadata()} dataFiles={dataFiles} />);
+    // Nothing zip-eligible, so the single-file save is shown instead.
+    expect(
+      screen.getByRole("button", { name: "Save dataset_description.json" }),
+    ).toBeInTheDocument();
+  });
+
+  test("saving the metadata file downloads it and confirms", async () => {
+    render(<Review jsPsychMetadata={makeMetadata()} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Save dataset_description.json" }),
+    );
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "✓ Saved" })).toBeInTheDocument();
+  });
+
+  test("downloading the zip bundles metadata plus data files and confirms", async () => {
+    const dataFiles = new Map([
+      ["my-experiment/sub01.csv", { content: "a,b\n1,2", type: "csv" }],
+    ]);
+    render(<Review jsPsychMetadata={makeMetadata()} dataFiles={dataFiles} />);
+    await userEvent.click(screen.getByRole("button", { name: "Download my-project.zip" }));
+
+    expect(await screen.findByRole("button", { name: "✓ Downloaded" })).toBeInTheDocument();
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  test("validates the metadata and eligible data files", async () => {
+    mockValidate.mockResolvedValue({ valid: true, errors: [], warnings: [] });
+    const dataFiles = new Map([
+      ["my-experiment/sub01.csv", { content: "a,b\n1,2", type: "csv" }],
+      ["my-experiment/notes.txt", { content: "notes", type: "txt" }],
+    ]);
+    render(<Review jsPsychMetadata={makeMetadata()} dataFiles={dataFiles} />);
+    await userEvent.click(screen.getByRole("button", { name: "Validate dataset" }));
+
+    expect(await screen.findByText("✓ Valid Psych-DS dataset")).toBeInTheDocument();
+    expect(mockValidate).toHaveBeenCalledWith(
+      expect.stringContaining('"my-project"'),
+      new Map([["my-experiment/sub01.csv", "a,b\n1,2"]]),
+    );
+    // Button switches to re-validate after a run.
+    expect(screen.getByRole("button", { name: "Re-validate" })).toBeInTheDocument();
+  });
+
+  test("shows errors and warnings with their evidence", async () => {
+    mockValidate.mockResolvedValue({
+      valid: false,
+      errors: [
+        {
+          key: "VARIABLE_MISSING_FROM_CSV_COLUMNS",
+          reason: "variable not found in CSV",
+          evidence: ["rt, stimulus"],
+        },
+        { key: "JSON_KEY_REQUIRED", reason: "missing required key", evidence: [] },
+      ],
+      warnings: [
+        { key: "MISSING_README", reason: "no README found", evidence: [] },
+      ],
+    });
+    render(<Review jsPsychMetadata={makeMetadata()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Validate dataset" }));
+
+    expect(await screen.findByText("✗ 2 errors found · 1 warning")).toBeInTheDocument();
+    expect(screen.getByText("Errors")).toBeInTheDocument();
+    expect(screen.getByText("VARIABLE_MISSING_FROM_CSV_COLUMNS")).toBeInTheDocument();
+    expect(screen.getByText("rt, stimulus")).toBeInTheDocument();
+    expect(screen.getByText("Warnings")).toBeInTheDocument();
+    expect(screen.getByText("MISSING_README")).toBeInTheDocument();
+  });
+
+  test("shows the validator's own message when validation is unavailable", async () => {
+    const err = new Error("The validator could not reach the schema server.");
+    err.name = "ValidationUnavailableError";
+    mockValidate.mockRejectedValue(err);
+    render(<Review jsPsychMetadata={makeMetadata()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Validate dataset" }));
+
+    expect(
+      await screen.findByText("The validator could not reach the schema server."),
+    ).toBeInTheDocument();
+  });
+
+  test("wraps unexpected validation failures in a generic message", async () => {
+    mockValidate.mockRejectedValue(new Error("boom"));
+    render(<Review jsPsychMetadata={makeMetadata()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Validate dataset" }));
+
+    expect(
+      await screen.findByText("Validation failed unexpectedly: boom"),
+    ).toBeInTheDocument();
+  });
+
+  test("keeps the CLI instructions available as a fallback", () => {
+    render(<Review jsPsychMetadata={makeMetadata()} />);
+    expect(screen.getByText("Prefer the command line?")).toBeInTheDocument();
+    expect(screen.getByText("npx @jspsych/cli validate")).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/tests/__mocks__/fileMock.cjs
+++ b/packages/frontend/tests/__mocks__/fileMock.cjs
@@ -1,0 +1,1 @@
+module.exports = "mock-file.svg";

--- a/packages/frontend/tests/__mocks__/jsonld.ts
+++ b/packages/frontend/tests/__mocks__/jsonld.ts
@@ -1,0 +1,3 @@
+// Stand-in for the `jsonld` package — validatePsychDS only assigns it to
+// `window.jsonld` for the validator's browser path, so identity is all that matters.
+export default { __mockJsonld: true };

--- a/packages/frontend/tests/__mocks__/psychds-validator-web.ts
+++ b/packages/frontend/tests/__mocks__/psychds-validator-web.ts
@@ -1,0 +1,4 @@
+// Stands in for the browser-only `psychds-validator/web/psychds-validator.js`
+// bundle (see moduleNameMapper in jest.config.cjs). Tests drive `validateWeb`
+// per-case via mockResolvedValue / mockRejectedValue.
+export const validateWeb = jest.fn();

--- a/packages/frontend/tests/__mocks__/styleMock.cjs
+++ b/packages/frontend/tests/__mocks__/styleMock.cjs
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/frontend/tests/datasetLayout.test.ts
+++ b/packages/frontend/tests/datasetLayout.test.ts
@@ -1,0 +1,21 @@
+import { DATASET_DESCRIPTION_FILENAME, dataFilePath } from "../src/datasetLayout";
+
+describe("DATASET_DESCRIPTION_FILENAME", () => {
+  test("is the canonical Psych-DS metadata filename", () => {
+    expect(DATASET_DESCRIPTION_FILENAME).toBe("dataset_description.json");
+  });
+});
+
+describe("dataFilePath", () => {
+  test("strips the top-level export folder and nests under data/", () => {
+    expect(dataFilePath("my-experiment/sub01.csv")).toBe("data/sub01.csv");
+  });
+
+  test("preserves nested subdirectories below the export folder", () => {
+    expect(dataFilePath("my-experiment/session1/sub01.csv")).toBe("data/session1/sub01.csv");
+  });
+
+  test("places a bare filename directly under data/", () => {
+    expect(dataFilePath("sub01.csv")).toBe("data/sub01.csv");
+  });
+});

--- a/packages/frontend/tests/setup.ts
+++ b/packages/frontend/tests/setup.ts
@@ -1,0 +1,24 @@
+import "@testing-library/jest-dom";
+
+// jsdom doesn't implement matchMedia (used by useTheme to read the OS color scheme).
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+// jsdom doesn't implement object URLs (used by the Review download buttons).
+URL.createObjectURL = jest.fn(() => "blob:mock-url");
+URL.revokeObjectURL = jest.fn();
+
+beforeEach(() => {
+  localStorage.clear();
+});

--- a/packages/frontend/tests/useTheme.test.ts
+++ b/packages/frontend/tests/useTheme.test.ts
@@ -1,0 +1,41 @@
+import { act, renderHook } from "@testing-library/react";
+import { useTheme } from "../src/hooks/useTheme";
+
+afterEach(() => {
+  delete document.documentElement.dataset.theme;
+});
+
+describe("useTheme", () => {
+  test("defaults to the OS preference when nothing is stored (mocked light)", () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(false);
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+
+  test("honors a stored 'dark' preference", () => {
+    localStorage.setItem("theme", "dark");
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(true);
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+
+  test("honors a stored 'light' preference", () => {
+    localStorage.setItem("theme", "light");
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(false);
+  });
+
+  test("toggle flips the theme, persists it, and updates the document", () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.toggle());
+    expect(result.current.isDark).toBe(true);
+    expect(localStorage.getItem("theme")).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+
+    act(() => result.current.toggle());
+    expect(result.current.isDark).toBe(false);
+    expect(localStorage.getItem("theme")).toBe("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+});

--- a/packages/frontend/tests/validatePsychDS.test.ts
+++ b/packages/frontend/tests/validatePsychDS.test.ts
@@ -1,0 +1,139 @@
+import jsonld from "jsonld";
+import { validateWeb } from "psychds-validator/web/psychds-validator.js";
+import {
+  validatePsychDS,
+  ValidationUnavailableError,
+} from "../src/validation/validatePsychDS";
+
+const mockValidateWeb = validateWeb as jest.Mock;
+
+/** jsdom's Blob has no .text(); read it through FileReader instead. */
+function blobText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+/** Builds a validator output object in the shape validatePsychDS consumes. */
+function validatorOutput(
+  issues: {
+    key: string;
+    reason: string;
+    severity: "error" | "warning";
+    evidence?: (string | undefined)[];
+  }[],
+) {
+  return {
+    issues: new Map(
+      issues.map((issue) => [
+        issue.key,
+        {
+          key: issue.key,
+          reason: issue.reason,
+          severity: issue.severity,
+          files: new Map(
+            (issue.evidence ?? []).map((evidence, i) => [`file${i}`, { evidence }]),
+          ),
+        },
+      ]),
+    ),
+  };
+}
+
+beforeEach(() => {
+  mockValidateWeb.mockReset();
+  delete (window as unknown as { jsonld?: unknown }).jsonld;
+});
+
+describe("validatePsychDS", () => {
+  test("exposes jsonld as a global for the validator's browser path", async () => {
+    mockValidateWeb.mockResolvedValue(validatorOutput([]));
+    await validatePsychDS("{}");
+    expect((window as unknown as { jsonld?: unknown }).jsonld).toBe(jsonld);
+  });
+
+  test("does not overwrite an existing window.jsonld", async () => {
+    const existing = { already: "here" };
+    (window as unknown as { jsonld?: unknown }).jsonld = existing;
+    mockValidateWeb.mockResolvedValue(validatorOutput([]));
+    await validatePsychDS("{}");
+    expect((window as unknown as { jsonld?: unknown }).jsonld).toBe(existing);
+  });
+
+  test("places dataset_description.json at the tree root and requests the latest schema", async () => {
+    mockValidateWeb.mockResolvedValue(validatorOutput([]));
+    await validatePsychDS('{"name":"test"}');
+
+    expect(mockValidateWeb).toHaveBeenCalledTimes(1);
+    const [tree, options] = mockValidateWeb.mock.calls[0];
+    expect(options).toEqual({ schema: "latest" });
+    expect(tree["dataset_description.json"].type).toBe("file");
+    await expect(blobText(tree["dataset_description.json"].file)).resolves.toBe('{"name":"test"}');
+  });
+
+  test("nests data files under data/, stripping the export folder", async () => {
+    mockValidateWeb.mockResolvedValue(validatorOutput([]));
+    const dataFiles = new Map([
+      ["my-experiment/sub01.csv", "a,b\n1,2"],
+      ["my-experiment/session1/sub02.csv", "a,b\n3,4"],
+    ]);
+    await validatePsychDS("{}", dataFiles);
+
+    const [tree] = mockValidateWeb.mock.calls[0];
+    const data = tree["data"];
+    expect(data.type).toBe("directory");
+    await expect(blobText(data.contents["sub01.csv"].file)).resolves.toBe("a,b\n1,2");
+    const session = data.contents["session1"];
+    expect(session.type).toBe("directory");
+    await expect(blobText(session.contents["sub02.csv"].file)).resolves.toBe("a,b\n3,4");
+  });
+
+  test("reports valid when the validator finds no issues", async () => {
+    mockValidateWeb.mockResolvedValue(validatorOutput([]));
+    const result = await validatePsychDS("{}");
+    expect(result).toEqual({ valid: true, errors: [], warnings: [] });
+  });
+
+  test("partitions issues into errors and warnings", async () => {
+    mockValidateWeb.mockResolvedValue(
+      validatorOutput([
+        { key: "JSON_KEY_REQUIRED", reason: "missing key", severity: "error" },
+        { key: "MISSING_README", reason: "no README", severity: "warning" },
+      ]),
+    );
+    const result = await validatePsychDS("{}");
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual([
+      { key: "JSON_KEY_REQUIRED", reason: "missing key", evidence: [] },
+    ]);
+    expect(result.warnings).toEqual([
+      { key: "MISSING_README", reason: "no README", evidence: [] },
+    ]);
+  });
+
+  test("dedupes per-file evidence and drops empty entries", async () => {
+    mockValidateWeb.mockResolvedValue(
+      validatorOutput([
+        {
+          key: "VARIABLE_MISSING_FROM_CSV_COLUMNS",
+          reason: "variable not in CSV",
+          severity: "error",
+          evidence: ["rt, stimulus", "rt, stimulus", "  ", undefined, "response"],
+        },
+      ]),
+    );
+    const result = await validatePsychDS("{}");
+    expect(result.errors[0].evidence).toEqual(["rt, stimulus", "response"]);
+  });
+
+  test("throws ValidationUnavailableError when the validator cannot run", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    mockValidateWeb.mockRejectedValue(new Error("fetch failed"));
+    await expect(validatePsychDS("{}")).rejects.toThrow(ValidationUnavailableError);
+    await expect(validatePsychDS("{}")).rejects.toThrow(/internet connection/);
+  });
+});

--- a/packages/frontend/tsconfig.app.json
+++ b/packages/frontend/tsconfig.app.json
@@ -27,5 +27,6 @@
     "typeRoots": ["./node_modules/@types", "./dist"],
     "types": []
   },
-  "include": ["src", "**/*.tsx"] // Make sure it includes your components directory
+  "include": ["src", "**/*.tsx"], // Make sure it includes your components directory
+  "exclude": ["tests", "node_modules", "dist"] // Tests run via Jest + sucrase; excluded from tsc -b since this tsconfig has no jest types
 }


### PR DESCRIPTION
## What

Adds a Jest test suite for `packages/frontend` — the package previously had no tests. Addresses #9.

36 tests across 6 suites, wired into the root Jest `projects` so `npm test` now covers all three packages (224 tests total).

## Structure

Mirrors `packages/cli`: a `tests/` directory at the package root named after the source modules, a `jest.config.cjs` using the `@sucrase/jest-plugin` transform, and a `"test": "jest"` script. Because this package renders React, the config adds what the CLI doesn't need: a jsdom environment, Testing Library, and CSS-module/asset mocks.

## Coverage

- **`validatePsychDS`** — the in-browser validation added by #92 (the implementation of #3): file-tree construction, error/warning partitioning, evidence dedup, the `window.jsonld` global, and the offline/unavailable error path
- **`Review`** — save/zip downloads, zip-eligibility filtering (non-CSV/JSON and uploaded `dataset_description.json` excluded), and the full validation UI flow: valid / errors+warnings with evidence / unavailable
- **`datasetLayout`** — the path mapping shared by the zip download and the validator
- **`Landing` / `App` / `useTheme`** — start flows (new vs. existing project), routing, start-over, theme persistence

## Notes for reviewers

- The `psychds-validator/web/` bundle is mocked via `moduleNameMapper` rather than per-test `jest.mock` — the deep import is blocked by the package's exports map, so Node can't load it at all; the mapping is required for any test that loads `validatePsychDS.ts`.
- `@jspsych/metadata` is mapped to its `src/` so tests don't require a prior build, matching how the metadata package's own tests import from source.
- `tests/` is excluded from `tsc -b` (this tsconfig has no jest types); tests run type-loose through sucrase. `npm run build` and `vite build` are unaffected.
- `npm run lint` failures in `src/` (51 problems) pre-exist on the base branch and are untouched here.

## Base branch

Stacked on `feat/frontend-validator` (#92) since the suite tests its validation UI. Once #92 merges, this will auto-retarget to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)