### PR TITLE
docs(frontend): add user README and developer architecture guide

### DIFF
--- a/docs/dev/frontend-architecture.md
+++ b/docs/dev/frontend-architecture.md
@@ -41,7 +41,7 @@ packages/frontend/
 │       └── node-stub.ts
 ```
 
-> **Legacy files still present:** `App.css`, `pages/Upload.tsx`, `pages/Options.tsx`, `pages/ViewOptions.tsx`, `components/ListItems.tsx`, `components/Preview.tsx`, `components/popups/`, `components/upload/`, `useExternalScripts.ts`. These are from the original modal-chain architecture and are no longer imported by any active code. They can be removed once the redesign is confirmed stable.
+> **Legacy files still present:** `pages/Upload.tsx`, `pages/Options.tsx`, `pages/ViewOptions.tsx`, `components/ListItems.tsx`, `components/Preview.tsx`, `components/popups/`, `components/upload/`, `useExternalScripts.ts`. These are from the original modal-chain architecture and are no longer imported by any active code. They can be removed once the redesign is confirmed stable. (`App.css` is *not* legacy — it is still imported by `App.tsx`.)
 
 ---
 
@@ -168,13 +168,13 @@ The wizard uses a single `JsPsychMetadata` instance created in `App.tsx` and pas
 | `setMetadataField(key, value)` | ProjectInfo | Write name, description, license, etc. |
 | `getMetadataField(key)` | ProjectInfo | Read back field values to pre-fill the form |
 | `generate(content, {}, format, options)` | DataUpload | Parse a data file and accumulate variable metadata |
-| `getVariables()` | Variables | Get the full variable map for display |
+| `getVariableList()` | Variables | Get all variable objects for display |
 | `getVariableNames()` | Variables | List variable names |
 | `getVariable(name)` | Variables | Read a single variable's metadata |
 | `updateVariable(name, key, value)` | Variables | Write user-edited description or type |
 | `getAuthorList()` | Authors | Read existing authors (for pre-filling on existing projects) |
-| `setAuthor(name, data)` | Authors | Add or update an author entry |
-| `removeAuthor(name)` | Authors | Remove an author |
+| `setAuthor(fields)` | Authors | Add or update an author entry (single `AuthorFields` object; keyed by `name`) |
+| `deleteAuthor(name)` | Authors | Remove an author |
 | `getMetadata()` | Review | Serialize the full metadata object to JSON |
 
 ---

--- a/docs/dev/frontend-architecture.md
+++ b/docs/dev/frontend-architecture.md
@@ -186,7 +186,7 @@ cd packages/frontend
 npm test
 ```
 
-Tests live in `packages/frontend/tests/` and use Jest + jsdom + Testing Library. See PR #96 for the full setup. The `psychds-validator/web/` bundle is mocked via `moduleNameMapper` (Node cannot load it — it is blocked by the package's exports map). `@jspsych/metadata` is mapped to its `src/` directory so tests run without a prior build.
+Tests live in `packages/frontend/tests/` and use Jest + jsdom + Testing Library. The `psychds-validator/web/` bundle is mocked via `moduleNameMapper` (Node cannot load it — it is blocked by the package's exports map). `@jspsych/metadata` is mapped to its `src/` directory so tests run without a prior build.
 
 ---
 
@@ -200,11 +200,11 @@ npm install
 cd packages/frontend
 npm run dev        # http://localhost:5173
 
-# type-check only (does not run Vite)
+# type-check + production build → dist/
 npm run build
 
 # lint
 npm run lint
 ```
 
-The metadata package is referenced as a local workspace dependency (`@jspsych/metadata: ^0.0.3`) and resolved from `packages/metadata/src` at dev time — no separate build step needed when iterating on the metadata package alongside the frontend.
+The metadata package is a local workspace dependency resolved from `packages/metadata/src` at dev time — no separate build step needed when iterating on the metadata package alongside the frontend.

--- a/docs/dev/frontend-architecture.md
+++ b/docs/dev/frontend-architecture.md
@@ -1,0 +1,210 @@
+# Frontend Package — Developer Guide
+
+This document describes the internal architecture of `packages/frontend` for contributors who want to understand, modify, or extend the web wizard.
+
+For user-facing documentation, see the [README](../../packages/frontend/README.md).
+
+---
+
+## Source structure
+
+```
+packages/frontend/
+├── index.html              — HTML shell; inline script sets data-theme before first paint
+├── src/
+│   ├── main.tsx            — React root mount
+│   ├── App.tsx             — top-level routing (landing ↔ wizard), theme toggle, JsPsychMetadata instance
+│   ├── index.css           — global CSS custom properties (design tokens), dark theme overrides, scrollbar
+│   ├── datasetLayout.ts    — shared constants: DATASET_DESCRIPTION_FILENAME, dataFilePath()
+│   │
+│   ├── pages/
+│   │   ├── Landing.tsx/.module.css     — welcome screen (new vs. existing project)
+│   │   ├── ProjectInfo.tsx/.module.css — step 1: dataset name, description, optional fields
+│   │   ├── DataUpload.tsx/.module.css  — step 2: folder/zip picker, join-key chooser
+│   │   ├── Variables.tsx/.module.css   — step 3: variable list with descriptions and types
+│   │   ├── Authors.tsx/.module.css     — step 4: author cards, bulk import
+│   │   └── Review.tsx/.module.css      — step 5: JSON viewer, download, in-browser validation
+│   │
+│   ├── components/
+│   │   ├── AppShell.tsx/.module.css    — wizard frame: sidebar + content area + preview pill
+│   │   ├── Sidebar.tsx/.module.css     — step navigation, Start Over dialog
+│   │   ├── PageHeader.tsx/.module.css  — fixed page header shared by all wizard pages
+│   │   ├── PreviewDrawer.tsx/.module.css — slide-in live JSON snapshot drawer
+│   │   └── JsonViewer.tsx/.module.css  — syntax-highlighted collapsible JSON renderer
+│   │
+│   ├── hooks/
+│   │   └── useTheme.ts     — dark/light theme: reads localStorage, falls back to OS preference
+│   │
+│   └── validation/         — in-browser Psych-DS validation (added by feat/frontend-validator)
+│       ├── validatePsychDS.ts
+│       ├── psychds-validator-web.d.ts
+│       └── node-stub.ts
+```
+
+> **Legacy files still present:** `App.css`, `pages/Upload.tsx`, `pages/Options.tsx`, `pages/ViewOptions.tsx`, `components/ListItems.tsx`, `components/Preview.tsx`, `components/popups/`, `components/upload/`, `useExternalScripts.ts`. These are from the original modal-chain architecture and are no longer imported by any active code. They can be removed once the redesign is confirmed stable.
+
+---
+
+## Entry point and top-level routing
+
+```
+index.html
+  └─ main.tsx  →  App.tsx
+                    ├─ page === 'landing'  →  Landing
+                    └─ page === 'main'     →  AppShell
+```
+
+`App.tsx` owns three things that outlive any single wizard step:
+
+| State | Type | Purpose |
+|-------|------|---------|
+| `page` | `'landing' \| 'main'` | Which top-level view is shown |
+| `jsPsychMetadata` | `JsPsychMetadata` | Single instance shared across all wizard steps |
+| `existingMetadataFile` | `File \| undefined` | Set when the user uploads a `dataset_description.json` on Landing |
+
+`handleStartOver` resets both `jsPsychMetadata` (new instance) and `existingMetadataFile`, then returns to `'landing'`. The theme toggle is rendered at `App` level so it persists across both views.
+
+---
+
+## Wizard state — AppShell
+
+`AppShell` manages the five-step wizard. Its key state:
+
+| State | Type | Purpose |
+|-------|------|---------|
+| `currentStep` | `StepId` | Which page is rendered in the content area |
+| `completedSteps` | `Set<StepId>` | Gates sidebar navigation |
+| `dataProcessed` | `boolean` | Whether `metadata.generate()` has been called at least once |
+| `dataSession` | `DataSession` | File references + texts from the Data step (persisted for Review) |
+| `projectInfoSession` | `ProjectInfoSession` | Field values from the Project Info step (persisted across re-renders) |
+| `previewOpen` | `boolean` | Whether the Preview drawer is open |
+
+### Step progression
+
+`completeStep(stepId)` adds the step to `completedSteps` then navigates forward to the first step that is not yet complete — skipping any steps pre-completed on load (e.g. the Data step is pre-completed for existing projects, so `completeStep('projectInfo')` jumps straight to Variables).
+
+`canNavigateTo(stepId)` returns `true` if the immediately preceding step is in `completedSteps`. The first step is always navigable. This means users can freely navigate back to any completed step but cannot skip forward.
+
+### Session objects
+
+Each stateful page (ProjectInfo, DataUpload) owns a "session" — a plain object holding UI state that should survive navigating away and back. The session and its setter are passed down from AppShell, not owned by the page component. This means the page re-renders with restored state when the user navigates back.
+
+```ts
+// DataUpload receives:
+session: DataSession          // current values
+onSessionChange: (s) => void  // update callback
+```
+
+`DataSession` holds the uploaded `File` objects and their text content (for passing to Review). `ProjectInfoSession` holds the form field values so they are not reset if the user steps back.
+
+---
+
+## Component breakdown
+
+### `Sidebar`
+
+Renders the left navigation rail. Receives `steps`, `currentStep`, `completedSteps`, `canNavigateTo`, `onNavigate`, and `onStartOver` as props — it owns no metadata state.
+
+The Start Over confirmation uses a native `<dialog>` (opened via `showModal()` with `useLayoutEffect`) for free focus trap and Escape key handling. The dialog is conditionally rendered (only in the DOM when `confirming === true`) to avoid a CSS `display: flex` / UA `display: none` conflict.
+
+### `PageHeader`
+
+A `position: fixed` header shared by all wizard pages, sitting flush to the top of the viewport and starting at `var(--sidebar-w)` from the left. Accepts a `title` and an optional `right` slot for page-specific controls. All wizard pages use it via composition rather than duplicating a sticky header.
+
+### `PreviewDrawer`
+
+A 420px slide-in panel (fixed, right edge) that renders a live JSON snapshot via `JsonViewer`. Opened by the `{} Preview` pill button in `AppShell`. Mounts fresh on each open — intentional, so the snapshot reflects the exact metadata state at the moment you click Preview rather than auto-updating as you type.
+
+### `JsonViewer`
+
+A recursive collapsible renderer for arbitrary JSON. Keys, strings, numbers, booleans, and null each get their own CSS class for syntax colouring (see `JsonViewer.module.css`). Arrays and objects render a toggle button to collapse their contents.
+
+---
+
+## Design system
+
+### CSS Modules
+
+Every component uses a co-located `.module.css` file. Class names are locally scoped by Vite's CSS Modules transform. Global CSS (design tokens, scrollbar, theme toggle button) lives in `src/index.css`.
+
+For applying a global selector inside a module (e.g. targeting `[data-theme="dark"]`), use `:global(...)`:
+```css
+:global([data-theme="dark"]) .myClass { color: red; }
+```
+
+### Design tokens (`index.css`)
+
+All colours are CSS custom properties on `:root`. Dark-mode overrides are on `:root[data-theme="dark"]`. `index.html` contains an inline script that sets `data-theme` synchronously before first paint, so there is no flash of the wrong theme.
+
+Key token groups:
+
+| Prefix | Purpose |
+|--------|---------|
+| `--c-forest-*` | Brand greens (progress indicators, completed checkmarks) |
+| `--c-amber*` | Amber (forward-progress CTA buttons only) |
+| `--c-ink*` | Text hierarchy (`--c-ink` → `--c-ink-4`, darkest to lightest in light mode) |
+| `--c-bg*` | Surface colours (page, sidebar, raised card, input) |
+| `--c-border*` | Border colours (standard and subtle) |
+| `--c-badge-*`, `--c-success-*`, `--c-warn-*`, `--c-danger-*` | Semantic status colours |
+| `--sidebar-w` | `211px` — sidebar width including its right border; used by `PageHeader` and `PreviewDrawer` |
+
+### `useTheme`
+
+`src/hooks/useTheme.ts` reads `localStorage.getItem('theme')`, falls back to `window.matchMedia('(prefers-color-scheme: dark)')`, and sets `document.documentElement.dataset.theme` in a `useEffect`. It exports `{ isDark, toggle }`. The inline script in `index.html` mirrors this logic synchronously so CSS loads with the right token values immediately.
+
+### Input style
+
+Inputs use a hybrid underline style: `1px solid` on all four sides normally, with only the bottom border activating on focus (`2px solid var(--c-forest-bright)` with a directional glow). This is defined in each page's module CSS rather than globally.
+
+---
+
+## `@jspsych/metadata` API used by the frontend
+
+The wizard uses a single `JsPsychMetadata` instance created in `App.tsx` and passed to every step.
+
+| Method | Step | Purpose |
+|--------|------|---------|
+| `loadMetadata(jsonString)` | ProjectInfo | Load an existing `dataset_description.json` |
+| `setMetadataField(key, value)` | ProjectInfo | Write name, description, license, etc. |
+| `getMetadataField(key)` | ProjectInfo | Read back field values to pre-fill the form |
+| `generate(content, {}, format, options)` | DataUpload | Parse a data file and accumulate variable metadata |
+| `getVariables()` | Variables | Get the full variable map for display |
+| `getVariableNames()` | Variables | List variable names |
+| `getVariable(name)` | Variables | Read a single variable's metadata |
+| `updateVariable(name, key, value)` | Variables | Write user-edited description or type |
+| `getAuthorList()` | Authors | Read existing authors (for pre-filling on existing projects) |
+| `setAuthor(name, data)` | Authors | Add or update an author entry |
+| `removeAuthor(name)` | Authors | Remove an author |
+| `getMetadata()` | Review | Serialize the full metadata object to JSON |
+
+---
+
+## Running the tests
+
+```
+cd packages/frontend
+npm test
+```
+
+Tests live in `packages/frontend/tests/` and use Jest + jsdom + Testing Library. See PR #96 for the full setup. The `psychds-validator/web/` bundle is mocked via `moduleNameMapper` (Node cannot load it — it is blocked by the package's exports map). `@jspsych/metadata` is mapped to its `src/` directory so tests run without a prior build.
+
+---
+
+## Development workflow
+
+```bash
+# from repo root
+npm install
+
+# run the frontend dev server
+cd packages/frontend
+npm run dev        # http://localhost:5173
+
+# type-check only (does not run Vite)
+npm run build
+
+# lint
+npm run lint
+```
+
+The metadata package is referenced as a local workspace dependency (`@jspsych/metadata: ^0.0.3`) and resolved from `packages/metadata/src` at dev time — no separate build step needed when iterating on the metadata package alongside the frontend.

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -1,30 +1,111 @@
-# React + TypeScript + Vite
+# jsPsych Metadata Generator — Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A browser-based wizard for generating [Psych-DS](https://psych-ds.github.io/) compliant `dataset_description.json` files from jsPsych experiment data. Mirrors the functionality of the CLI tool in a point-and-click interface.
 
-Currently, two official plugins are available:
+---
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Running locally
 
-## Expanding the ESLint configuration
+1. Clone the repository and install dependencies from the root:
+   ```
+   git clone https://github.com/jspsych/metadata.git
+   cd metadata
+   npm install
+   ```
+2. Start the development server:
+   ```
+   cd packages/frontend
+   npm run dev
+   ```
+3. Open [http://localhost:5173](http://localhost:5173) in your browser.
 
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
+Node.js 18 or later is required.
 
-- Configure the top-level `parserOptions` property like this:
+---
 
-```js
-export default {
-  // other rules...
-  parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-    project: ['./tsconfig.json', './tsconfig.node.json', './tsconfig.app.json'],
-    tsconfigRootDir: __dirname,
-  },
-}
+## Using the wizard
+
+### Welcome screen
+
+Choose one of two starting points:
+
+- **Create new project** — start from scratch. The wizard will walk you through each step and produce a downloadable Psych-DS project.
+- **Open existing project** — upload an existing `dataset_description.json` to continue editing or update the metadata after adding new data files.
+
+A **☾ Dark / ☀ Light** toggle in the top-right corner switches the colour theme. Your choice is remembered across sessions.
+
+---
+
+### Step 1 — Project Info
+
+Fill in basic information about your dataset:
+
+- **Project name** *(required)* — used as the dataset identifier and as the downloaded folder name.
+- **Description** — a plain-English summary of the experiment. Defaults to "No description provided." if left blank.
+- **License, funding source, keywords, citation** *(optional)* — additional Psych-DS recommended fields.
+
+You can also upload an existing `dataset_description.json` here to pre-fill all fields, with a before/after comparison when the uploaded values differ from anything you have already entered.
+
+---
+
+### Step 2 — Data
+
+Upload your jsPsych data files (`.csv` or `.json`):
+
+- Click **Choose folder** to browse for a directory (uses the browser's folder picker) **or** click **Upload zip** to upload a `.zip` containing your data files.
+- Each file is shown with a status indicator once processed.
+- If your data files contain nested arrays, the wizard detects whether `trial_index` uniquely identifies each row. If not, a join-key chooser lets you select additional columns before proceeding — these are used to name the separate CSV files the validator expects.
+
+> **For existing projects:** the Data step is pre-marked complete since your variables are already loaded from the uploaded `dataset_description.json`. You can still upload new data files to regenerate the variable list.
+
+---
+
+### Step 3 — Variables
+
+Review and annotate each variable detected in your data:
+
+- Variables with **unknown descriptions** (those the plugin cache could not fill in automatically) appear in an expanded section at the top.
+- Known variables start collapsed. Use **Expand all / Collapse all** to open or close all rows at once.
+- Each row has a **Description** text area and a **Type** dropdown. Editing either updates the metadata immediately.
+- Long level lists are truncated at five entries with a **Show all N** toggle.
+
+---
+
+### Step 4 — Authors
+
+Add contributors to the dataset:
+
+- Click **Add author** to create a new row. Type a name and press Tab or click away to commit it.
+- Expand a row to fill in optional fields: given name, family name, author type, ORCID.
+- **Bulk import** lets you paste a list of names (one per line, optionally followed by an ORCID) to add multiple authors at once. Invalid ORCIDs are flagged with a warning banner.
+
+---
+
+### Step 5 — Review
+
+Inspect the generated `dataset_description.json` and download your project:
+
+- The JSON viewer shows a syntax-highlighted, collapsible preview of the output.
+- Click **Download `<project-name>.zip`** to download a complete Psych-DS project archive:
+  ```
+  <project-name>.zip
+  ├── dataset_description.json
+  ├── README.md
+  ├── CHANGES.md
+  └── data/
+      └── <your data files>
+  ```
+- If no data files were uploaded, a **Save `dataset_description.json`** button is shown instead.
+- **Validate dataset** runs the Psych-DS validator in-browser and shows any errors or warnings inline. An internet connection is required (the validator fetches the schema from GitHub).
+
+The **{} Preview** pill button (visible on all steps except Review) opens a live JSON snapshot in a slide-in drawer so you can check the output at any point without leaving the current step.
+
+---
+
+## Building for production
+
+```
+npm run build
 ```
 
-- Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
-- Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+Output is written to `packages/frontend/dist/`. Serve it with any static file host.


### PR DESCRIPTION
## Summary

- Replaces the Vite boilerplate `packages/frontend/README.md` with a full user-facing guide: local setup, 5-step wizard walkthrough, and build instructions. Closes the two open items in #23.
- Adds `docs/dev/frontend-architecture.md`: developer reference covering source structure (including legacy files still present), entry point routing, AppShell wizard state and session pattern, component breakdown, design system (CSS Modules, tokens, useTheme), `@jspsych/metadata` API surface, and test/dev workflow. Closes #6.

Stacked on `feat/frontend-redesign` (#85) — base will auto-retarget to `main` once #85 merges.

## Test plan

- [ ] Review `packages/frontend/README.md` for accuracy (steps, file names, npm commands)
- [ ] Review `docs/dev/frontend-architecture.md` for accuracy against current source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)