### PR TITLE
fix(build,cli): repair Node ESM entry, cli script, and spurious pre-write validation

### DIFF
--- a/.changeset/fix-cli-spurious-prewrite-validation.md
+++ b/.changeset/fix-cli-spurious-prewrite-validation.md
@@ -1,0 +1,11 @@
+---
+"@jspsych/metadata-cli": patch
+---
+
+fix(cli): don't print a spurious validation failure for existing projects
+
+When opening an existing project, validation ran before the data files were
+copied into the project, so it always failed with `MISSING_DATA_DIRECTORY` and
+printed a misleading `✘ Psych-DS validation failed` to stderr even when the final
+output was valid. Removed that pre-write call; the post-write validation that
+actually gates the result is unchanged.

--- a/.changeset/fix-metadata-esm-entry.md
+++ b/.changeset/fix-metadata-esm-entry.md
@@ -1,0 +1,12 @@
+---
+"@jspsych/metadata": patch
+---
+
+fix(metadata): make the Node ESM entry (`dist/index.js`) loadable
+
+The build runs esbuild (which emits the bundled `dist/index.js`) followed by
+`tsc`. With `declaration: true` and `outDir: ./dist` but no `emitDeclarationOnly`,
+`tsc` re-emitted an unbundled `dist/index.js` over esbuild's bundle, leaving
+extensionless relative imports (e.g. `./utils`) that Node's ESM loader rejects.
+Added `emitDeclarationOnly: true` so `tsc` emits only the `.d.ts` declarations and
+esbuild's working bundle survives; type-checking and `dist/index.d.ts` are unchanged.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,7 @@
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "esbuild src/index.ts --bundle --format=esm --platform=node --external:psychds-validator --outfile=dist/esm/index.js",
     "build:cjs": "esbuild src/index.ts --bundle --format=cjs --platform=node --external:psychds-validator --outfile=dist/cjs/index.cjs",
-    "cli": "node dist/esm/index.js",
+    "cli": "node dist/cjs/index.cjs",
     "test": "jest"
   },
   "devDependencies": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -400,8 +400,10 @@ const main = async () => {
       project_path = argv['psych-ds-dir'];
       new_project = false;
       await loadMetadata(metadata, project_path + "/dataset_description.json"); // maybe shoudl add verbose
-      // project_path is argv['psych-ds-dir'] (a string) inside this branch — no typeof guard needed here.
-      await validatePsychDS(project_path, verbose); // informational only — result not acted on here
+      // NOTE: we intentionally do NOT validate here. At this point the data files have not been
+      // copied into the project yet, so validation would always fail with MISSING_DATA_DIRECTORY
+      // and print a misleading "✘ validation failed" to stderr. The real validation runs after the
+      // data is written (see below).
       if (verbose) console.log(`\n\n-------------------------- Reading existing metadata --------------------------\n\n${JSON.stringify(metadata.getMetadata(), null, 2)}`);
   }
   else {

--- a/packages/metadata/tsconfig.json
+++ b/packages/metadata/tsconfig.json
@@ -7,6 +7,10 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declaration": true,
+    // esbuild (esbuild.config.mjs) produces all runtime JS bundles; tsc runs only to emit
+    // type declarations. Without this, tsc also writes dist/index.js — clobbering esbuild's
+    // bundle with extensionless relative imports that Node ESM cannot resolve.
+    "emitDeclarationOnly": true,
     "outDir": "./dist", // Output directory for compiled files
     "rootDir": "./src", // Root directory of input files
     "declarationDir": "./dist", // Directory for declaration files


### PR DESCRIPTION
Fixes three issues surfaced by stress-testing (see #100 — the P1/P2/F3 items). All three are independent, low-risk, and need no behavior decision.

## Changes

**P1 — `dist/index.js` (the Node ESM entry) was unloadable.**
The metadata build is `node esbuild.config.mjs && npx tsc`. With `declaration: true` and `outDir: ./dist` but no `emitDeclarationOnly`, `tsc` re-emitted `dist/index.js` *over* esbuild's bundle, leaving extensionless relative imports (`./utils`) that Node ESM rejects. Added `emitDeclarationOnly: true` so `tsc` emits only `.d.ts` and esbuild's bundle survives.

**P2 — the `cli` npm script was unrunnable.**
`"cli": "node dist/esm/index.js"` runs the ESM bundle, but the package is `"type": "commonjs"`, so Node parses it as CJS and fails. Pointed the script at the working `dist/cjs/index.cjs` (the same entry `bin` uses).

**F3 — CLI printed a spurious "validation failed" to stderr.**
For an existing project, `validatePsychDS` ran *before* the data files were copied in, so it always failed with `MISSING_DATA_DIRECTORY` and printed a misleading `✘ Psych-DS validation failed` to stderr — even when the final output was valid. Removed that pre-write call; the post-write validation (which actually gates the result) is unchanged.

## Verification
- `npm run build` passes; `dist/index.js` now loads under Node ESM and `dist/index.d.ts` is still emitted.
- The `dist/cjs/index.cjs` entry runs (`--help`).
- End-to-end CLI runs no longer emit the spurious stderr validation failure; real validation still reports 0 errors on valid output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)