### PR TITLE
fix(metadata): type trial_type-less rows and absorb boolean/string mix

### DIFF
--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -596,17 +596,11 @@ export default class JsPsychMetadata {
    * @returns {*}
    */
   private async generateMetadata(variable, value, pluginType, version, extension?) {
-    if (!pluginType) { 
-      return;
-    }
-    // probably should work in a call to the plugin here
-    const pluginInfo = await this.getPluginInfo(pluginType, variable, version, extension);
-    const description = pluginInfo["description"];
-    const new_description = description
-      ? { [pluginType]: description }
-      : { [pluginType]: "unknown" };
-    var type = typeof value;
+    const type = typeof value;
 
+    // Register the column (or upgrade a value:"unknown" placeholder) with its concrete type. This is
+    // independent of the plugin: a row without a trial_type still has typed columns whose values must
+    // feed min/max and levels — only the human-readable description (below) comes from the plugin.
     if (!this.containsVariable(variable)) {
       const new_var = {
         "@type": "PropertyValue",
@@ -622,8 +616,17 @@ export default class JsPsychMetadata {
       if (existing.value === "unknown") this.updateVariable(variable, "value", type);
     }
 
-    // hit the update variable decription fields
-    this.updateVariable(variable, "description", new_description);
+    // Plugin/extension description lookup needs a plugin type. Rows without one (e.g. a row missing
+    // trial_type) keep the default "unknown" description but are still typed and counted.
+    if (pluginType) {
+      const pluginInfo = await this.getPluginInfo(pluginType, variable, version, extension);
+      const description = pluginInfo["description"];
+      const new_description = description
+        ? { [pluginType]: description }
+        : { [pluginType]: "unknown" };
+      this.updateVariable(variable, "description", new_description);
+    }
+
     this.updateFields(variable, value, type);
   }
 
@@ -682,6 +685,13 @@ export default class JsPsychMetadata {
         delete existing.minValue;
         delete existing.maxValue;
         this.updateVariable(variable, "value", "string");
+      }
+      // F2: a column already typed boolean (a genuine true/false was seen) may also receive the
+      // STRING "true"/"false" — e.g. the same field encoded as text in another row. Treat it as the
+      // same boolean rather than recording a misleading categorical level. Any other string still
+      // accumulates as a level (a real mix).
+      if (existing.value === "boolean" && (value === "true" || value === "false")) {
+        return;
       }
       this.updateVariable(variable, "levels", value);
     }
@@ -953,7 +963,8 @@ export default class JsPsychMetadata {
     if (this.containsVariable(name) && (this.getVariable(name) as VariableFields).value !== "unknown") return;
     await this.generateMetadata(name, value, pluginType, version);
     if (!this.containsVariable(name)) {
-      // generateMetadata is a no-op without a pluginType — declare the column anyway.
+      // Defensive: generateMetadata registers the column itself (even without a pluginType), but
+      // declare it here too in case it is ever reached without registration.
       this.setVariable({ "@type": "PropertyValue", name, description: { default: "unknown" }, value: type });
     } else {
       this.updateVariable(name, "value", type); // typeof {}/[] === "object"; pin the intended type

--- a/packages/metadata/tests/metadata-row-typing-fixes.test.ts
+++ b/packages/metadata/tests/metadata-row-typing-fixes.test.ts
@@ -1,0 +1,172 @@
+import JsPsychMetadata from "../src/index";
+
+// Regression tests for PR #102 (issue #100, items F1/F2).
+//
+//  F1 — generateMetadata previously returned early when a row had no trial_type, which
+//       skipped not just the plugin-description lookup but also the column's type
+//       registration and min/max/levels update. A row without a trial_type must still
+//       type its columns and feed min/max/levels; only the plugin-sourced *description*
+//       is skipped when trial_type is absent.
+//
+//  F2 — a column already typed boolean (a genuine true/false was seen) absorbs the
+//       STRING "true"/"false" instead of recording it as a misleading categorical level.
+//       Any other string still accumulates as a real level. PR #90's pure-boolean and
+//       pure-string behavior is unchanged.
+
+const mockFetch = jest.fn().mockResolvedValue({ text: () => Promise.resolve("") });
+
+const BASE = { trial_type: "mock-plugin", trial_index: 0, time_elapsed: 100 };
+
+describe("F1: trial_type-less rows are still typed and counted", () => {
+  beforeEach(() => {
+    (global as any).fetch = mockFetch;
+    mockFetch.mockClear();
+  });
+
+  test("F1a: a numeric value in a row without trial_type still feeds min/max", async () => {
+    const data = JSON.stringify([
+      { ...BASE, trial_index: 0, rt: 300 },
+      { trial_index: 1, time_elapsed: 200, rt: 9999 }, // no trial_type
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const rt = meta.getVariable("rt") as any;
+    expect(rt.value).toBe("number");
+    expect(rt.minValue).toBe(300);
+    expect(rt.maxValue).toBe(9999); // would be 300 before the fix — row 2's value was dropped
+  });
+
+  test("F1b (string): a column only in a trial_type-less row is typed, not left value:'unknown'", async () => {
+    const data = JSON.stringify([
+      { ...BASE, trial_index: 0 },
+      { trial_index: 1, time_elapsed: 200, orphan_col: "hello" }, // no trial_type
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const v = meta.getVariable("orphan_col") as any;
+    expect(v.value).toBe("string"); // was "unknown" before the fix
+    expect(v.levels).toContain("hello");
+  });
+
+  test("F1b (number): a numeric-only column in a trial_type-less row is typed number with min/max", async () => {
+    const data = JSON.stringify([
+      { ...BASE, trial_index: 0 },
+      { trial_index: 1, time_elapsed: 200, orphan_num: 42 }, // no trial_type
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const v = meta.getVariable("orphan_num") as any;
+    expect(v.value).toBe("number");
+    expect(v.minValue).toBe(42);
+    expect(v.maxValue).toBe(42);
+  });
+
+  test("only the plugin-sourced description is skipped without a trial_type", async () => {
+    // orphan_col never co-occurs with a trial_type, so no plugin description is looked up:
+    // it keeps the default description but is still fully typed.
+    const data = JSON.stringify([
+      { trial_index: 0, time_elapsed: 100, orphan_col: "x" }, // no trial_type at all
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const v = meta.getVariable("orphan_col") as any;
+    expect(v.value).toBe("string");
+    expect(v.description).toEqual({ default: "unknown" });
+  });
+});
+
+describe("F2: a boolean column absorbs the string 'true'/'false'", () => {
+  beforeEach(() => {
+    (global as any).fetch = mockFetch;
+    mockFetch.mockClear();
+  });
+
+  test("genuine boolean first, then string 'false' — no misleading level is recorded", async () => {
+    const data = JSON.stringify([
+      { ...BASE, trial_index: 0, correct: true },
+      { ...BASE, trial_index: 1, correct: "false" },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const v = meta.getVariable("correct") as any;
+    expect(v.value).toBe("boolean");
+    expect(v.levels).toBeUndefined(); // "false" absorbed, not recorded as a categorical level
+  });
+
+  test("both string 'true' and 'false' across rows are absorbed into the boolean column", async () => {
+    const data = JSON.stringify([
+      { ...BASE, trial_index: 0, correct: true },
+      { ...BASE, trial_index: 1, correct: "true" },
+      { ...BASE, trial_index: 2, correct: "false" },
+      { ...BASE, trial_index: 3, correct: false },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const v = meta.getVariable("correct") as any;
+    expect(v.value).toBe("boolean");
+    expect(v.levels).toBeUndefined();
+  });
+
+  test("a non-boolean string in a boolean column is still recorded as a real mix", async () => {
+    const data = JSON.stringify([
+      { ...BASE, trial_index: 0, resp: true },
+      { ...BASE, trial_index: 1, resp: "maybe" },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const v = meta.getVariable("resp") as any;
+    expect(v.levels).toContain("maybe"); // genuinely mixed → level kept, not absorbed
+  });
+
+  // Documents the known order-dependent limitation raised in review of #102: if the STRING
+  // "true"/"false" arrives BEFORE any genuine boolean, the column is already typed "string"
+  // with levels ["true"], and the later genuine boolean returns early in updateFields — so the
+  // level is not retroactively removed. Pinning this makes a future symmetric fix a deliberate,
+  // visible change rather than a silent one.
+  test("KNOWN LIMITATION: string 'true' seen before a genuine boolean stays a string level", async () => {
+    const data = JSON.stringify([
+      { ...BASE, trial_index: 0, flag: "true" },
+      { ...BASE, trial_index: 1, flag: true },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const v = meta.getVariable("flag") as any;
+    expect(v.value).toBe("string");
+    expect(v.levels).toContain("true");
+  });
+
+  test("PR #90 behavior unchanged: a pure-boolean column has no levels", async () => {
+    const data = JSON.stringify([
+      { ...BASE, trial_index: 0, done: true },
+      { ...BASE, trial_index: 1, done: false },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const v = meta.getVariable("done") as any;
+    expect(v.value).toBe("boolean");
+    expect(v.levels).toBeUndefined();
+  });
+
+  test("PR #90 behavior unchanged: a pure-string 'true'/'false' column keeps both levels", async () => {
+    // No genuine boolean is ever seen, so the column stays categorical with both levels.
+    const data = JSON.stringify([
+      { ...BASE, trial_index: 0, label: "true" },
+      { ...BASE, trial_index: 1, label: "false" },
+    ]);
+    const meta = new JsPsychMetadata();
+    await meta.generate(data);
+
+    const v = meta.getVariable("label") as any;
+    expect(v.value).toBe("string");
+    expect(v.levels).toEqual(expect.arrayContaining(["true", "false"]));
+  });
+});


### PR DESCRIPTION
Fixes the remaining items from #100 (the F1/F2 findings). Independent of #101 (different files), so the two can merge in any order; together they resolve #100.

## Changes (both in `packages/metadata/src/index.ts`)

**F1 — rows without a `trial_type` were skipped entirely.**
`generateMetadata` returned early when there was no `trial_type`, which skipped not just the plugin-description lookup but also the column's type registration and its min/max/levels update. These are now decoupled: a column is typed and its values feed min/max/levels regardless of `trial_type`; only the plugin-sourced *description* is skipped (it stays `"unknown"`).
- **F1a:** a value living in a `trial_type`-less row (e.g. `rt: 9999`) is no longer dropped from the numeric range.
- **F1b:** a column that appears only in such a row no longer stays `value: "unknown"` — it gets typed.

**F2 — a boolean/string mixed column kept the string as a misleading level.**
A column mixing genuine JSON booleans with the *string* `"true"`/`"false"` was typed boolean yet carried `levels: ["true"]`. The string is now absorbed into the boolean column (no level) rather than recorded; any *other* string still mixes. PR #90's pure-boolean (no levels) and pure-string (`"true"`/`"false"` kept as levels) behavior is unchanged.

## Verification
- On the nested stress fixture: `rt.maxValue === 9999` (F1a), `orphan_col` typed `string` (F1b), `correct` is boolean with no levels (F2).
- Regression checks hold: a pure-boolean column keeps no levels, and a pure-string `bool_string` column keeps `["TRUE", "false"]`.
- Full metadata test suite passes (127 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)