### PR TITLE
fix(metadata): collapse variableMeasured.description to schema.org Text

### DIFF
--- a/.changeset/description-object-to-text.md
+++ b/.changeset/description-object-to-text.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata": patch
+---
+
+`variableMeasured.description` is now always serialized as a single schema.org Text value. When a column accumulated genuinely different descriptions from multiple plugins, `getList()` previously emitted `description` as an object (`{ pluginType: text }`), which made the Psych-DS validator raise an `OBJECT_TYPE_MISSING` warning. The distinct descriptions are now joined into one string with `" | "`. `getList()` is also idempotent now (a second call no longer mangles an already-collapsed string description), and empty descriptions collapse to `"unknown"`.

--- a/packages/metadata/src/VariablesMap.ts
+++ b/packages/metadata/src/VariablesMap.ts
@@ -134,44 +134,49 @@ export class VariablesMap {
   getList(): {}[] {
     var var_list = [];
 
-    // need to check that this works as intended
     for (const key of Object.keys(this.variables)) {
       const variable = this.variables[key];
-      const description = variable["description"];
-      const numKeys = Object.keys(description).length;
-
-      if (numKeys === 0) console.error("Empty description"); // error: description empty
-      else if (numKeys === 1) {
-        // description becomes single field (assumed to be default)
-        const key = Object.keys(description)[0];
-        variable["description"] = description[key];
-      } else if (numKeys == 2) {
-        delete description["default"]; // deletes default
-        // Delete the property if its value is "unknown"
-        for (const descKey in description as object) {
-          if (description[descKey] === "unknown") {
-            delete description[descKey];
-          }
-        }
-        if (Object.keys(description).length == 1) {
-          // error checking that it reduced to one key
-          const key = Object.keys(description)[0];
-          variable["description"] = description[key];
-        }
-      } else if (numKeys > 2) {
-        // deletes default
-        delete description["default"];
-        // Delete the property if its value is "unknown"
-        for (const descKey in description as object) {
-          if (description[descKey] === "unknown") {
-            delete description[descKey];
-          }
-        }
-      }
-
+      variable["description"] = this.collapseDescription(variable["description"]);
       var_list.push(variable);
     }
     return var_list;
+  }
+
+  /**
+   * Collapses an internal { pluginType: description } map into a single schema.org-valid
+   * Text value. Descriptions are stored per-plugin and only ever hold multiple keys when the
+   * texts genuinely differ (identical texts are merged upstream in updateDescription). Psych-DS /
+   * schema.org require `description` to be Text, so an object value triggers an OBJECT_TYPE_MISSING
+   * validator warning — this folds everything down to a string.
+   *
+   * @private
+   * @param {*} description - The description value (a { pluginType: text } map, or already a string).
+   * @returns {string} - A single Text description.
+   */
+  private collapseDescription(description): string {
+    // Already collapsed (string from a prior getList, or a user-set description) — leave untouched.
+    if (typeof description !== "object" || description === null) {
+      return description;
+    }
+
+    if (Object.keys(description).length === 0) {
+      console.error("Empty description");
+      return "unknown";
+    }
+
+    // Drop the synthetic "default" once real plugin descriptions exist.
+    if (Object.keys(description).length > 1 && "default" in description) {
+      delete description["default"];
+    }
+    // Drop placeholder "unknown" entries while at least one real description remains.
+    for (const descKey of Object.keys(description)) {
+      if (description[descKey] === "unknown" && Object.keys(description).length > 1) {
+        delete description[descKey];
+      }
+    }
+
+    // Join the remaining distinct descriptions into one Text value.
+    return (Object.values(description) as string[]).join(" | ");
   }
 
   /**

--- a/packages/metadata/tests/metadata-maps.test.ts
+++ b/packages/metadata/tests/metadata-maps.test.ts
@@ -252,8 +252,17 @@ describe("VariablesMap", () => {
       value: "string",
     };
 
+    // Distinct per-plugin descriptions collapse to a single " | "-joined Text value
+    // (an object value would trigger the validator's OBJECT_TYPE_MISSING warning).
+    let expected = {
+      "@type": "PropertyValue",
+      name: "animation style",
+      description: "how tall the user is | what the user likes to eat",
+      value: "string",
+    };
+
     variablesMap.setVariable(two_key);
-    expect([two_key]).toStrictEqual(variablesMap.getList());
+    expect([expected]).toStrictEqual(variablesMap.getList());
   });
 
   test("#gettingListTwoKeyDefault", () => {
@@ -298,17 +307,61 @@ describe("VariablesMap", () => {
       value: "string",
     };
 
+    // "default" is dropped, then the remaining distinct descriptions join into one Text value.
     let expected = {
       "@type": "PropertyValue",
       name: "animation style",
-      description: {
-        diet: "what the user likes to eat",
-        hamburger: "how many hamburgers the user ate",
-      },
+      description: "what the user likes to eat | how many hamburgers the user ate",
       value: "string",
     };
 
     variablesMap.setVariable(add_default);
     expect([expected]).toStrictEqual(variablesMap.getList());
+  });
+
+  test("#gettingListEmptyDescription", () => {
+    for (const variable of variable_data) {
+      variablesMap.deleteVariable(variable["name"]);
+    }
+
+    let empty_desc = {
+      "@type": "PropertyValue",
+      name: "animation style",
+      description: {},
+      value: "string",
+    };
+
+    let expected = {
+      "@type": "PropertyValue",
+      name: "animation style",
+      description: "unknown",
+      value: "string",
+    };
+
+    variablesMap.setVariable(empty_desc);
+    expect([expected]).toStrictEqual(variablesMap.getList());
+  });
+
+  test("#gettingListIsIdempotent", () => {
+    for (const variable of variable_data) {
+      variablesMap.deleteVariable(variable["name"]);
+    }
+
+    let two_key = {
+      "@type": "PropertyValue",
+      name: "animation style",
+      description: {
+        grown: "how tall the user is",
+        diet: "what the user likes to eat",
+      },
+      value: "string",
+    };
+
+    variablesMap.setVariable(two_key);
+    const first = variablesMap.getList();
+    // A second call must not re-process the now-string description (no per-character mangling).
+    const second = variablesMap.getList();
+    expect(second).toStrictEqual(first);
+    expect(second[0]["description"]).toBe("how tall the user is | what the user likes to eat");
   });
 });


### PR DESCRIPTION
## Summary

The Psych-DS validator raises an `OBJECT_TYPE_MISSING` warning on generated `dataset_description.json` because `variableMeasured.description` is sometimes an **object** instead of schema.org Text.

Descriptions are stored internally as `{ pluginType: text }` maps and only ever hold multiple keys when the texts genuinely differ across plugins (identical texts are merged upstream in `updateDescription`). `VariablesMap.getList()` previously only flattened to a string when it could reduce to a single key, leaving the 2+-distinct-key cases as objects — which is what the validator flags.

## Changes

- `getList()` now delegates per-variable to a new private `collapseDescription()` helper that:
  - leaves an already-collapsed string untouched (**idempotency** — a second `getList()` call no longer mangles the string),
  - drops the synthetic `default` key when other keys exist,
  - drops placeholder `"unknown"` entries while real ones remain,
  - **joins any remaining distinct descriptions into one Text value with `" | "`**,
  - collapses an empty description to `"unknown"`.
- Updated the two tests that asserted the old object output; added empty-description and idempotency tests.
- Added a changeset (`@jspsych/metadata` patch).

## Verification

Full metadata suite: **133/133 pass**.

Ran the real CLI binary non-interactively on `~/Desktop/metadata-test` (38-file eye-tracking dataset) with the real `psychds-validator`:

- **`OBJECT_TYPE_MISSING` eliminated** — warnings dropped 10 → 9 (remaining are all known/benign: unofficial-keyword, invalid-schemaorg-property, file-not-checked, missing recommended dirs).
- Generated metadata: **100 variables, 0 object-valued descriptions**, 4 multi-plugin cases collapsed cleanly, e.g. `num_points → "Number of calibration points used | Number of validation points used"`.
- Also confirmed on event-boundary (145 files, 51 vars) → 0 object-valued descriptions.

Both the CLI and frontend funnel through the same `getMetadata() → getList()`; rebuilt both bundles and confirmed each now carries `collapseDescription`.

## Out of scope (separate pre-existing issues, noted for follow-up)

- A corrupt-JSDoc-parse artifact on the `success` column (`"True` fragment) — a different bug; this PR correctly joins whatever descriptions exist.
- `npm run build --workspaces` builds cli/frontend before metadata, leaving consumer bundles stale unless metadata is built first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)