### PR TITLE
test(frontend): cover validatePsychDS file-tree and severity-routing edge cases (#94)

### DIFF
--- a/packages/frontend/tests/helpers.ts
+++ b/packages/frontend/tests/helpers.ts
@@ -3,7 +3,9 @@ export function validatorOutput(
   issues: {
     key: string;
     reason: string;
-    severity: "error" | "warning";
+    // The validator emits "ignore" alongside "error"/"warning"; include it so tests can
+    // assert it's routed to neither bucket without casting at the call site.
+    severity: "error" | "warning" | "ignore";
     evidence?: (string | undefined)[];
   }[],
 ) {

--- a/packages/frontend/tests/validatePsychDS.test.ts
+++ b/packages/frontend/tests/validatePsychDS.test.ts
@@ -107,10 +107,73 @@ describe("validatePsychDS", () => {
     expect(result.errors[0].evidence).toEqual(["rt, stimulus", "response"]);
   });
 
+  test("reports valid with warnings present as long as there are no errors", async () => {
+    mockValidateWeb.mockResolvedValue(
+      validatorOutput([
+        { key: "MISSING_README", reason: "no README", severity: "warning" },
+        { key: "MISSING_CHANGES", reason: "no CHANGES", severity: "warning" },
+      ]),
+    );
+    const result = await validatePsychDS("{}");
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toHaveLength(2);
+  });
+
+  test("drops issues whose severity is neither error nor warning", async () => {
+    // The validator also emits 'ignore'-severity issues; these must not leak into
+    // either bucket (and must not flip `valid`).
+    mockValidateWeb.mockResolvedValue(
+      validatorOutput([
+        { key: "SOME_IGNORED_RULE", reason: "ignored", severity: "ignore" },
+      ] as Parameters<typeof validatorOutput>[0]),
+    );
+    const result = await validatePsychDS("{}");
+    expect(result).toEqual({ valid: true, errors: [], warnings: [] });
+  });
+
   test("throws ValidationUnavailableError when the validator cannot run", async () => {
     jest.spyOn(console, "error").mockImplementation(() => {});
     mockValidateWeb.mockRejectedValue(new Error("fetch failed"));
     await expect(validatePsychDS("{}")).rejects.toThrow(ValidationUnavailableError);
     await expect(validatePsychDS("{}")).rejects.toThrow(/internet connection/);
+  });
+});
+
+describe("buildFileTree (via validatePsychDS)", () => {
+  beforeEach(() => mockValidateWeb.mockResolvedValue(validatorOutput([])));
+
+  test("an empty data-files map produces no data/ directory", async () => {
+    await validatePsychDS("{}", new Map());
+    const [tree] = mockValidateWeb.mock.calls[0];
+    expect(tree["data"]).toBeUndefined();
+    expect(tree["dataset_description.json"].type).toBe("file");
+  });
+
+  test("normalizes leading and duplicate slashes when nesting paths", async () => {
+    await validatePsychDS("{}", new Map([["/data//raw/sub01.json", "[]"]]));
+    const [tree] = mockValidateWeb.mock.calls[0];
+    // Empty segments from the leading/double slash are dropped, so the file still
+    // lands at data/raw/sub01.json rather than under an empty-named directory.
+    expect(tree[""]).toBeUndefined();
+    const raw = tree["data"].contents["raw"];
+    expect(raw.type).toBe("directory");
+    expect(raw.contents["sub01.json"].type).toBe("file");
+  });
+
+  test("nests a deep (3-level) path, creating each intermediate directory", async () => {
+    await validatePsychDS("{}", new Map([["data/raw/session1/sub01.json", "[]"]]));
+    const [tree] = mockValidateWeb.mock.calls[0];
+    const session = tree["data"].contents["raw"].contents["session1"];
+    expect(session.type).toBe("directory");
+    expect(session.contents["sub01.json"].type).toBe("file");
+  });
+
+  test("ignores a path with no filename (no-op, no stray entries)", async () => {
+    // "/" collapses to zero segments under filter(Boolean), leaving no filename to
+    // place, so insertFile bails out and the tree keeps only the metadata file.
+    await validatePsychDS("{}", new Map([["/", "ignored"]]));
+    const [tree] = mockValidateWeb.mock.calls[0];
+    expect(Object.keys(tree)).toEqual(["dataset_description.json"]);
   });
 });

--- a/packages/frontend/tests/validatePsychDS.test.ts
+++ b/packages/frontend/tests/validatePsychDS.test.ts
@@ -126,7 +126,7 @@ describe("validatePsychDS", () => {
     mockValidateWeb.mockResolvedValue(
       validatorOutput([
         { key: "SOME_IGNORED_RULE", reason: "ignored", severity: "ignore" },
-      ] as Parameters<typeof validatorOutput>[0]),
+      ]),
     );
     const result = await validatePsychDS("{}");
     expect(result).toEqual({ valid: true, errors: [], warnings: [] });


### PR DESCRIPTION
## Summary

Fills the remaining unit-test gaps for the in-browser Psych-DS validator helpers (`packages/frontend/src/validation/validatePsychDS.ts`), closing out #94.

**Context — much of #94 was already addressed:** #108 added the bulk of the coverage (jsonld global, error/warning partitioning, evidence dedup, file-tree building), and `datasetLayout.ts` has since been reduced to a single filename constant (the `dataFilePath`/layout mapping moved into `DataUpload.tsx`), so that bullet of the issue no longer applies. This PR adds the edge cases not yet covered.

## New tests (all via the public `validatePsychDS` API — no private exports)

- **warnings-only → `valid: true`** — a dataset with only advisory warnings is still valid
- **non-error/non-warning severity dropped** — `ignore`-severity issues don't leak into either bucket or flip `valid`
- **slash normalization** — `/data//raw/x` nests correctly (`filter(Boolean)`)
- **deep (3-level) nesting** — each intermediate directory is created
- **empty data-files map** — produces no stray `data/` directory
- **no-filename path** (`"/"`) — `insertFile` no-ops cleanly

## Testing

`npx jest` in `packages/frontend` — all 229 tests pass (+6).

Tests-only change, so no changeset.

Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)