### PR TITLE
perf(metadata,cli,frontend): parse each data file once instead of twice (#95)

### DIFF
--- a/.changeset/parse-once-per-file.md
+++ b/.changeset/parse-once-per-file.md
@@ -1,0 +1,6 @@
+---
+"@jspsych/metadata": patch
+"@jspsych/metadata-cli": patch
+---
+
+Parse each data file once instead of twice. `JsPsychMetadata.generate()` now accepts data that is already a parsed array of observations (not just a JSON/CSV string); when given an array it skips parsing, and the caller can pass `synthesizedSourceRecordId` so the synthetic-id description is still applied. The CLI's `processDirectory`/`processFile` now parse a file a single time and hand the rows to `generate()` and to the Psych-DS CSV builder, rather than parsing once for metadata and again for conversion. No change to generated metadata or output files; this reduces CPU and peak memory on large datasets (e.g. multi-MB jsPsych/Tobii exports). Spun out of #95.

--- a/packages/cli/src/data.ts
+++ b/packages/cli/src/data.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import JsPsychMetadata, { analyzeJoinKeys, JoinKeyAnalysis, parseCSV, parseJsonData, objectsToCSV, isValidPsychDSDataFilename, buildPsychDSDataFiles, stripUnnamedColumns, PSYCHDS_IGNORE_FILENAME, PSYCHDS_IGNORE_CONTENT } from "@jspsych/metadata";
+import JsPsychMetadata, { analyzeJoinKeys, JoinKeyAnalysis, parseCSV, parseJsonData, objectsToCSV, isValidPsychDSDataFilename, buildPsychDSDataFiles, PSYCHDS_IGNORE_FILENAME, PSYCHDS_IGNORE_CONTENT } from "@jspsych/metadata";
 import { expandHomeDir, disambiguateFilename, fileStem } from "./utils";
 import { PlannedFile } from "./rename";
 
@@ -342,22 +342,40 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
     const content = await fs.promises.readFile(filePath, "utf8");
     const fileExtension = path.extname(file).toLowerCase();
 
-    switch (fileExtension){
-      case '.json':
-      case '.jsonl':
-        if (file === "dataset_description.json") metadata.loadMetadata(content); // need to remove this for the files that are being called with the CLI
-        else await metadata.generate(content, {}, 'json', options);
-        break;
-      case '.csv':
-        await metadata.generate(content, {}, 'csv', options);
-        break;
-      default:
-        console.error(`"${file}" is not .csv, .json, or .jsonl format.`);
+    // Rows parsed from this file, reused by the conversion path below so the file is parsed
+    // once rather than once here and again per output. Empty for dataset_description.json,
+    // which is loaded as existing metadata and never parsed/generated from.
+    let parsedRows: Array<Record<string, any>> = [];
+    // A clean CSV (no blank/whitespace-only headers) can be written back byte-for-byte. Recorded
+    // before generate() strips parsedRows in place — the conversion path reuses those same rows,
+    // so it can no longer detect the dropped columns itself.
+    let csvVerbatimEligible = false;
+    if (file === "dataset_description.json") {
+      metadata.loadMetadata(content);
+    } else if (isJsonDataExt(fileExtension)) {
+      // Tag a per-line source_record_id for JSON-Lines (a no-op for a single array) so the main
+      // CSV carries the same join-key column generate() promotes for the sidecars. Validate
+      // before generating so a non-array (or unparseable) file is skipped without side effects.
+      const stats: { synthesizedSourceRecordId?: boolean } = {};
+      const json = parseJsonData(content, { tagSourceRecordId: true }, stats);
+      if (!Array.isArray(json)) {
+        console.error(`"${file}" is not a JSON array of jsPsych trials; skipping.`);
         return false;
+      }
+      parsedRows = json;
+      // Hand the already-parsed rows to generate() so it doesn't re-parse the same content.
+      await metadata.generate(parsedRows, {}, 'json', { ...options, synthesizedSourceRecordId: stats.synthesizedSourceRecordId === true });
+    } else if (fileExtension === '.csv') {
+      parsedRows = (await parseCSV(content)) as Array<Record<string, any>>;
+      csvVerbatimEligible = !parsedRows.some((r) => Object.keys(r).some((k) => k.trim() === ''));
+      await metadata.generate(parsedRows, {}, 'csv', options);
+    } else {
+      console.error(`"${file}" is not .csv, .json, or .jsonl format.`);
+      return false;
     }
 
     if (targetDirectoryPath) {
-      // dataset_description.json takes the loadMetadata() branch above. Copy it through
+      // dataset_description.json was loaded as existing metadata above. Copy it through
       // unchanged and skip conversion + array extraction (the latter would re-write the
       // previous data file's array rows under a filename derived from this one).
       if (file === "dataset_description.json") {
@@ -365,25 +383,11 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
         return true;
       }
 
-      // For JSON sources, parse and validate first so a non-array (or unparseable) file is
-      // skipped before it reserves an output name — otherwise it would needlessly disambiguate
-      // a later valid file that maps to the same base.
-      let parsed: Array<Record<string, any>> | null = null;
-      if (isJsonDataExt(fileExtension)) {
-        // Tag a per-line source_record_id for JSON-Lines (a no-op for a single array) so the main
-        // CSV carries the same join-key column generate() promotes for the sidecars.
-        const json = parseJsonData(content, { tagSourceRecordId: true });
-        if (!Array.isArray(json)) {
-          console.error(`"${file}" is not a JSON array of jsPsych trials; skipping CSV conversion.`);
-          return false;
-        }
-        parsed = json;
-      }
-
-      // Rows for the main table, fed to the shared builder / inline write. JSON is already
-      // parsed above; parse CSV here too so unnamed row-index columns can be stripped (a CSV's
-      // exact bytes are still preserved via mainContent when nothing is dropped).
-      const mainRows: Array<Record<string, any>> = parsed ?? ((await parseCSV(content)) as Array<Record<string, any>>);
+      // Reuse the rows parsed (and fed to generate()) above — no second parse. `parsed` is the
+      // JSON row array (null for CSV) so the verbatim-bytes / raw-preservation logic below still
+      // distinguishes a JSON source from a CSV one.
+      const parsed: Array<Record<string, any>> | null = isJsonDataExt(fileExtension) ? parsedRows : null;
+      const mainRows: Array<Record<string, any>> = parsedRows;
 
       // Resolve the Psych-DS base (keyword-value sequence before "_data.csv"). The index.ts
       // pre-pass supplies a base for every source file; fall back to the file's own stem when
@@ -471,12 +475,11 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
         };
 
         const mainName = reserve(planned.mainName, 'main output');
-        // Drop R-style unnamed row-index columns (same as the shared builder / generate()). A clean
-        // CSV keeps its exact bytes; JSON or a dirty CSV is serialised from the cleaned rows.
-        const { rows: cleanedMain, dropped: droppedMain } = stripUnnamedColumns(mainRows);
+        // A clean CSV keeps its exact bytes; JSON or a dirty CSV (whose unnamed row-index columns
+        // generate() already stripped from mainRows) is serialised from those cleaned rows.
         await fs.promises.writeFile(
           path.join(targetDirectoryPath, mainName),
-          (parsed === null && droppedMain.length === 0) ? content : objectsToCSV(cleanedMain, ['trial_index']),
+          csvVerbatimEligible ? content : objectsToCSV(mainRows, ['trial_index']),
         );
         if (verbose) console.log(`  → wrote ${file} as ${mainName}`);
 
@@ -497,7 +500,7 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
         const built = buildPsychDSDataFiles({
           base,
           mainRows,
-          mainContent: parsed ? undefined : content,
+          mainContent: csvVerbatimEligible ? content : undefined,
           extractedArrays,
           extractedObjects,
           joinKeys,

--- a/packages/cli/src/data.ts
+++ b/packages/cli/src/data.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import JsPsychMetadata, { analyzeJoinKeys, JoinKeyAnalysis, parseCSV, parseJsonData, objectsToCSV, isValidPsychDSDataFilename, buildPsychDSDataFiles, PSYCHDS_IGNORE_FILENAME, PSYCHDS_IGNORE_CONTENT } from "@jspsych/metadata";
+import JsPsychMetadata, { analyzeJoinKeys, JoinKeyAnalysis, parseCSV, parseJsonData, objectsToCSV, isValidPsychDSDataFilename, buildPsychDSDataFiles, hasUnnamedColumns, PSYCHDS_IGNORE_FILENAME, PSYCHDS_IGNORE_CONTENT } from "@jspsych/metadata";
 import { expandHomeDir, disambiguateFilename, fileStem } from "./utils";
 import { PlannedFile } from "./rename";
 
@@ -367,7 +367,7 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
       await metadata.generate(parsedRows, {}, 'json', { ...options, synthesizedSourceRecordId: stats.synthesizedSourceRecordId === true });
     } else if (fileExtension === '.csv') {
       parsedRows = (await parseCSV(content)) as Array<Record<string, any>>;
-      csvVerbatimEligible = !parsedRows.some((r) => Object.keys(r).some((k) => k.trim() === ''));
+      csvVerbatimEligible = !hasUnnamedColumns(parsedRows);
       await metadata.generate(parsedRows, {}, 'csv', options);
     } else {
       console.error(`"${file}" is not .csv, .json, or .jsonl format.`);
@@ -383,11 +383,9 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
         return true;
       }
 
-      // Reuse the rows parsed (and fed to generate()) above — no second parse. `parsed` is the
-      // JSON row array (null for CSV) so the verbatim-bytes / raw-preservation logic below still
-      // distinguishes a JSON source from a CSV one.
-      const parsed: Array<Record<string, any>> | null = isJsonDataExt(fileExtension) ? parsedRows : null;
-      const mainRows: Array<Record<string, any>> = parsedRows;
+      // Reuse the rows parsed (and fed to generate()) above — no second parse. The verbatim-bytes
+      // decision is carried by csvVerbatimEligible; raw-preservation below keys off the source type
+      // via isJsonDataExt(fileExtension) directly.
 
       // Resolve the Psych-DS base (keyword-value sequence before "_data.csv"). The index.ts
       // pre-pass supplies a base for every source file; fall back to the file's own stem when
@@ -422,7 +420,7 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
       // have no separate "raw" form). data/raw/ is flat (one level deep is flattened), so
       // same-named originals from different source subdirectories must be disambiguated or
       // they would overwrite one another.
-      if (parsed) {
+      if (isJsonDataExt(fileExtension)) {
         const rawDir = path.join(targetDirectoryPath, 'raw');
         await fs.promises.mkdir(rawDir, { recursive: true });
         const rawName = disambiguateFilename(file, usedRawFilenames);
@@ -479,7 +477,7 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
         // generate() already stripped from mainRows) is serialised from those cleaned rows.
         await fs.promises.writeFile(
           path.join(targetDirectoryPath, mainName),
-          csvVerbatimEligible ? content : objectsToCSV(mainRows, ['trial_index']),
+          csvVerbatimEligible ? content : objectsToCSV(parsedRows, ['trial_index']),
         );
         if (verbose) console.log(`  → wrote ${file} as ${mainName}`);
 
@@ -499,7 +497,7 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
         // disambiguation, and CSV building — the same implementation the browser flow uses.
         const built = buildPsychDSDataFiles({
           base,
-          mainRows,
+          mainRows: parsedRows,
           mainContent: csvVerbatimEligible ? content : undefined,
           extractedArrays,
           extractedObjects,

--- a/packages/cli/tests/data.test.ts
+++ b/packages/cli/tests/data.test.ts
@@ -577,6 +577,28 @@ describe("processDirectory JSON → CSV conversion", () => {
     const csv = fs.readFileSync(path.join(dataDir, "subject-9_data.csv"), "utf8");
     expect(csv.split(/\r?\n/)[0].split(",")).not.toContain("");
   });
+
+  // Parse-once guard: the file is parsed a single time and the rows (not the raw string) are
+  // handed to generate(), so a large file isn't re-parsed for metadata and again for the CSV.
+  test("parses each file once: generate() receives parsed rows, not the raw string", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    const dataDir = path.join(tmpDir, "data");
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(dataDir);
+    fs.writeFileSync(path.join(srcDir, "subject-1_data.json"), JSON.stringify([{ trial_index: 0, rt: 1 }]));
+    fs.writeFileSync(path.join(srcDir, "subject-2_data.csv"), "trial_index,rt\n0,1");
+
+    const metadata = new JsPsychMetadata();
+    const generateSpy = jest.spyOn(metadata, "generate"); // keeps the real implementation
+    await processDirectory(metadata, srcDir, false, dataDir);
+
+    expect(generateSpy).toHaveBeenCalledTimes(2);
+    for (const call of generateSpy.mock.calls) {
+      expect(Array.isArray(call[0])).toBe(true);
+      expect(typeof call[0]).not.toBe("string");
+    }
+    generateSpy.mockRestore();
+  });
 });
 
 // #109 finding #3: a fully-flagged headless run must not block on the interactive join-key prompt.

--- a/packages/cli/tests/data.test.ts
+++ b/packages/cli/tests/data.test.ts
@@ -595,7 +595,6 @@ describe("processDirectory JSON → CSV conversion", () => {
     expect(generateSpy).toHaveBeenCalledTimes(2);
     for (const call of generateSpy.mock.calls) {
       expect(Array.isArray(call[0])).toBe(true);
-      expect(typeof call[0]).not.toBe("string");
     }
     generateSpy.mockRestore();
   });

--- a/packages/frontend/src/pages/DataUpload.tsx
+++ b/packages/frontend/src/pages/DataUpload.tsx
@@ -266,31 +266,39 @@ const DataUpload: React.FC<DataUploadProps> = ({
       }
 
       try {
-        await jsPsychMetadata.generate(content, {}, type as 'json' | 'csv', {
-          arrayJoinKeys: joinKeys,
-          suppressJoinKeyWarning: suppressWarning,
-        });
-
-        // Convert this file to its Psych-DS datafile(s) immediately: getExtracted* reflect
-        // only the most recent generate() call, so this must happen before the next iteration.
-        // JSON arrays are serialised to CSV; CSV is written verbatim. Non-array JSON is skipped
-        // (it isn't a jsPsych trial table) — matching the CLI.
+        // Parse the file once here and hand the rows to generate(), then reuse the same rows to
+        // build the Psych-DS datafile(s) — so a large file isn't parsed twice. Conversion must
+        // happen immediately: getExtracted* reflect only the most recent generate() call. JSON
+        // arrays are serialised to CSV; CSV is written verbatim. Non-array JSON is skipped (it
+        // isn't a jsPsych trial table) before generate() runs — matching the CLI.
         let mainRows: Array<Record<string, any>> = [];
         let mainContent: string | undefined;
         if (type === 'json') {
           // Tag a per-line source_record_id for JSON-Lines (a no-op for a single array) so the
           // main CSV carries the same join-key column generate() promotes for the sidecars.
-          const json = parseJsonData(content, { tagSourceRecordId: true });
+          const stats: { synthesizedSourceRecordId?: boolean } = {};
+          const json = parseJsonData(content, { tagSourceRecordId: true }, stats);
           if (!Array.isArray(json)) {
             update(i, { status: 'skipped', detail: 'not a jsPsych trial array' });
             continue;
           }
           mainRows = json;
+          await jsPsychMetadata.generate(mainRows, {}, 'json', {
+            arrayJoinKeys: joinKeys,
+            suppressJoinKeyWarning: suppressWarning,
+            synthesizedSourceRecordId: stats.synthesizedSourceRecordId === true,
+          });
         } else {
-          mainContent = content;
-          // Parse CSV rows too so the builder can drop R-style unnamed row-index columns; a clean
-          // CSV still keeps its exact bytes (mainContent is used verbatim when nothing is dropped).
+          // Parse CSV rows so the builder can drop R-style unnamed row-index columns. A clean CSV
+          // keeps its exact bytes (mainContent verbatim); record that eligibility before generate()
+          // strips mainRows in place, since the builder can no longer detect the drop afterwards.
           mainRows = (await parseCSV(content)) as Array<Record<string, unknown>>;
+          const csvVerbatimEligible = !mainRows.some((r) => Object.keys(r).some((k) => k.trim() === ''));
+          await jsPsychMetadata.generate(mainRows, {}, 'csv', {
+            arrayJoinKeys: joinKeys,
+            suppressJoinKeyWarning: suppressWarning,
+          });
+          if (csvVerbatimEligible) mainContent = content;
         }
 
         const built = buildPsychDSDataFiles({

--- a/packages/frontend/src/pages/DataUpload.tsx
+++ b/packages/frontend/src/pages/DataUpload.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import JSZip from 'jszip';
-import JsPsychMetadata, { analyzeJoinKeys, deriveFallbackBase, buildPsychDSDataFiles, isValidPsychDSDataFilename, parseCSV, parseJsonData, PSYCHDS_IGNORE_FILENAME, PSYCHDS_IGNORE_CONTENT } from '@jspsych/metadata';
+import JsPsychMetadata, { analyzeJoinKeys, deriveFallbackBase, buildPsychDSDataFiles, hasUnnamedColumns, isValidPsychDSDataFilename, parseCSV, parseJsonData, PSYCHDS_IGNORE_FILENAME, PSYCHDS_IGNORE_CONTENT } from '@jspsych/metadata';
 import PageHeader from '../components/PageHeader';
 import styles from './DataUpload.module.css';
 
@@ -293,7 +293,7 @@ const DataUpload: React.FC<DataUploadProps> = ({
           // keeps its exact bytes (mainContent verbatim); record that eligibility before generate()
           // strips mainRows in place, since the builder can no longer detect the drop afterwards.
           mainRows = (await parseCSV(content)) as Array<Record<string, unknown>>;
-          const csvVerbatimEligible = !mainRows.some((r) => Object.keys(r).some((k) => k.trim() === ''));
+          const csvVerbatimEligible = !hasUnnamedColumns(mainRows);
           await jsPsychMetadata.generate(mainRows, {}, 'csv', {
             arrayJoinKeys: joinKeys,
             suppressJoinKeyWarning: suppressWarning,

--- a/packages/frontend/tests/DataUpload.test.tsx
+++ b/packages/frontend/tests/DataUpload.test.tsx
@@ -263,13 +263,15 @@ describe("DataUpload", () => {
       await userEvent.click(screen.getByRole("button", { name: "Process files" }));
     }
 
-    test("calls generate once per CSV file with correct args", async () => {
+    test("calls generate once per CSV file with the parsed rows", async () => {
       const { container } = render(<DataUpload {...props()} />);
       await pickAndProcess(makeFile("sub01.csv", "rt,stimulus\n100,hello"), container);
 
       await waitFor(() => expect(meta.generate).toHaveBeenCalledTimes(1));
+      // The file is parsed once up front and the rows (not the raw string) are handed to
+      // generate(), so it doesn't re-parse the same content.
       expect(meta.generate).toHaveBeenCalledWith(
-        "rt,stimulus\n100,hello",
+        expect.any(Array),
         {},
         "csv",
         expect.any(Object),
@@ -309,7 +311,8 @@ describe("DataUpload", () => {
       await pickAndProcess(makeFile("data.json", content), container);
 
       await waitFor(() => expect(meta.generate).toHaveBeenCalledTimes(1));
-      expect(meta.generate).toHaveBeenCalledWith(content, {}, "json", expect.any(Object));
+      // generate() receives the parsed rows array, not the raw JSON string (parsed once up front).
+      expect(meta.generate).toHaveBeenCalledWith(expect.any(Array), {}, "json", expect.any(Object));
       expect(screen.queryByText(/Rows need a unique identifier/)).not.toBeInTheDocument();
     });
 
@@ -366,7 +369,7 @@ describe("DataUpload", () => {
 
       await waitFor(() => expect(meta.generate).toHaveBeenCalled());
       expect(meta.generate).toHaveBeenCalledWith(
-        expect.any(String),
+        expect.any(Array),
         {},
         "json",
         expect.objectContaining({
@@ -385,7 +388,7 @@ describe("DataUpload", () => {
       await userEvent.click(screen.getByRole("button", { name: "Apply and process files" }));
       await waitFor(() => expect(meta.generate).toHaveBeenCalled());
       expect(meta.generate).toHaveBeenCalledWith(
-        expect.any(String),
+        expect.any(Array),
         {},
         "json",
         expect.objectContaining({ arrayJoinKeys: ["trial_index"], suppressJoinKeyWarning: true }),

--- a/packages/frontend/tests/DataUpload.test.tsx
+++ b/packages/frontend/tests/DataUpload.test.tsx
@@ -14,6 +14,7 @@ jest.mock("@jspsych/metadata", () => ({
   // files, which the component only iterates over — an empty list is sufficient for these tests.
   parseJsonData: jest.fn((content: string) => JSON.parse(content)),
   parseCSV: jest.fn(() => []),
+  hasUnnamedColumns: jest.fn(() => false),
   buildPsychDSDataFiles: jest.fn(() => []),
   deriveFallbackBase: jest.fn((stem: string) => `subject-${stem}`),
   isValidPsychDSDataFilename: jest.fn(() => false),

--- a/packages/metadata/README.md
+++ b/packages/metadata/README.md
@@ -21,7 +21,7 @@ await metadata.generate(properties);
 
 | Parameter | Type | Description
 ----------|------|------------
-| data      | object, string | The data file that was generated from running a JsPsych experiment. This can be passed in as string Json, string CSV or as an object. Depending on the type of data will need to change the CSV flag. |
+| data      | array, string | The data file that was generated from running a JsPsych experiment. This can be passed in as a JSON string, a CSV string, or an already-parsed array of observation objects. Depending on the type of data you will need to change the `format` flag. **Note:** when you pass a pre-parsed array it is consumed in place and *mutated* — unnamed (blank-header) columns are deleted from the row objects. If you need the rows to stay pristine, pass a copy. |
 | metadata  | object | Optional metadata that can be passed in to adjust the output of the generate method. Each key-value pair will map to a parameter field, and will either overwite existing data or create new fields. All normal fields can be adjusted as entries within the object, but for authors and variables the entries need to be nested within an "author" or "variables" key mapping. Similarily, updating the descriptions of variables needs to be a nested map. |
 | format       | boolean|  Optional flag that should be marked 'csv' if data is in a string csv format. If passing in as an object can specify as 'json' or leave blank. |
 

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -427,19 +427,24 @@ export default class JsPsychMetadata {
    * @param {Object} [metadata={}] - Optional metadata to be processed. Each key-value pair in this object will be processed individually.
    * @param {boolean} [csv=false] - Flag indicating if the data is in a string CSV. If true, the data will be parsed as CSV.
    */
-  async generate(data, metadata = {}, ext = 'json', options: { arrayJoinKeys?: string[]; suppressJoinKeyWarning?: boolean } = {}) {
+  async generate(data, metadata = {}, ext = 'json', options: { arrayJoinKeys?: string[]; suppressJoinKeyWarning?: boolean; synthesizedSourceRecordId?: boolean } = {}) {
     this.extractedArrays = new Map();
     this.extractedObjects = new Map();
     this.arrayJoinKeys = options.arrayJoinKeys ?? ['trial_index'];
 
     var parsed_data;
 
-    if (ext === 'csv') {
+    // Accept data already parsed by the caller (an array of observations) so a file isn't
+    // parsed twice when the caller also needs the rows — e.g. the CLI/web conversion path,
+    // which builds the main CSV from these same rows. A pre-parsed caller owns any
+    // source_record_id tagging and tells us whether it synthesized one via options; when we
+    // parse a JSON string ourselves we derive it from the parse below.
+    let synthesizedSourceRecordId = options.synthesizedSourceRecordId ?? false;
+    if (Array.isArray(data)) {
+      parsed_data = data;
+    } else if (ext === 'csv') {
       parsed_data = await parseCSV(data);
-    }
-
-    let synthesizedSourceRecordId = false;
-    if (ext === 'json') {
+    } else if (ext === 'json') {
       // Accepts both a single JSON array (standard jsPsych export) and JSON-Lines,
       // where each line is its own JSON value (JATOS exports one participant array per line).
       // Tag JSON-Lines rows with a per-line source_record_id: raw jsPsych exports carry no

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -415,17 +415,21 @@ export default class JsPsychMetadata {
    * Generates observations based on the input data and processes optional metadata. This is the
    * outer wrapper function that should called and handles the logic of reading individual observations.
    *
-   * This method accepts data, which can be an array of observation objects, a JSON string,
-   * or a CSV string. If the data is in CSV format, set the `csv` parameter to `true` to
-   * parse it into a JSON object. Each observation is processed asynchronously using the
-   * `generateObservation` method. Optionally, metadata options can be provided in the form of an
-   * object, and each key-value pair in the metadata object will be processed by the
-   * `processMetadata` method.
+   * This method accepts data as a JSON string, a CSV string, or an already-parsed array of
+   * observation objects. A string is parsed according to `ext`; an array is consumed as-is.
+   * Each observation is processed asynchronously via `generateObservation`. Optionally, metadata
+   * options can be provided as an object, and each key-value pair is processed by `processMetadata`.
+   *
+   * NOTE: when `data` is a pre-parsed array it is consumed in place and MUTATED — unnamed
+   * (blank-header) columns are deleted from the row objects. Callers that need the rows to stay
+   * pristine must pass a copy. This lets a caller parse a file once and share the rows with
+   * generate() instead of having generate() re-parse the same content.
    *
    * @async
-   * @param {Array|String} data - The data to generate observations from. Can be an array of objects, a JSON string, or a CSV string.
+   * @param {Array|String} data - Observations to generate from: a pre-parsed array (consumed as-is and mutated in place), a JSON string, or a CSV string.
    * @param {Object} [metadata={}] - Optional metadata to be processed. Each key-value pair in this object will be processed individually.
-   * @param {boolean} [csv=false] - Flag indicating if the data is in a string CSV. If true, the data will be parsed as CSV.
+   * @param {'json'|'csv'} [ext='json'] - Format of a string `data`; ignored when `data` is already an array.
+   * @param {Object} [options={}] - arrayJoinKeys / suppressJoinKeyWarning, plus synthesizedSourceRecordId for pre-parsed callers that tagged a synthetic source_record_id themselves.
    */
   async generate(data, metadata = {}, ext = 'json', options: { arrayJoinKeys?: string[]; suppressJoinKeyWarning?: boolean; synthesizedSourceRecordId?: boolean } = {}) {
     this.extractedArrays = new Map();

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -1099,5 +1099,5 @@ export {
   AuthorFields,
   VariableFields
 }
-export { analyzeJoinKeys, parseCSV, parseJsonData, unwrapTrials, isValidPsychDSDataFilename, toPsychDSValue, deriveArrayFilename, objectsToCSV, disambiguateArrayFilename, deriveFallbackBase, buildPsychDSDataFiles, stripUnnamedColumns, PSYCHDS_IGNORE_FILENAME, PSYCHDS_IGNORE_CONTENT } from "./utils";
+export { analyzeJoinKeys, parseCSV, parseJsonData, unwrapTrials, isValidPsychDSDataFilename, toPsychDSValue, deriveArrayFilename, objectsToCSV, disambiguateArrayFilename, deriveFallbackBase, buildPsychDSDataFiles, stripUnnamedColumns, hasUnnamedColumns, PSYCHDS_IGNORE_FILENAME, PSYCHDS_IGNORE_CONTENT } from "./utils";
 export type { JoinKeyAnalysis, PsychDSDataFile, BuildPsychDSDataFilesArgs } from "./utils";

--- a/packages/metadata/src/utils.ts
+++ b/packages/metadata/src/utils.ts
@@ -409,6 +409,22 @@ export function disambiguateArrayFilename(base: string, used: Set<string>): stri
   return candidate;
 }
 
+/** A column header is "unnamed" when it is empty or whitespace-only — the unnamed row-index
+ *  column R's `write.csv` prepends. The single source of truth for that rule; both
+ *  {@link stripUnnamedColumns} and {@link hasUnnamedColumns} use it so they can never diverge. */
+const isUnnamedHeader = (key: string): boolean => key.trim() === "";
+
+/**
+ * True when any row carries an {@link isUnnamedHeader unnamed} column. Lets a caller decide,
+ * *before* `generate()` mutates the rows in place, whether a CSV source can be written back
+ * byte-for-byte (no unnamed columns) or must be re-serialised from the cleaned rows. Kept as a
+ * shared predicate so the CLI and browser conversion paths share one definition of "unnamed"
+ * with {@link stripUnnamedColumns}, rather than each re-implementing the header scan.
+ */
+export function hasUnnamedColumns(rows: Array<Record<string, any>>): boolean {
+  return rows.some((row) => Object.keys(row).some(isUnnamedHeader));
+}
+
 /**
  * Removes columns whose name is empty or whitespace-only from every row, in place,
  * and reports which names were dropped. R's `write.csv` (with the default
@@ -425,7 +441,7 @@ export function stripUnnamedColumns(
   const unnamed = new Set<string>();
   for (const row of rows) {
     for (const key of Object.keys(row)) {
-      if (key.trim() === "") unnamed.add(key);
+      if (isUnnamedHeader(key)) unnamed.add(key);
     }
   }
   if (unnamed.size > 0) {


### PR DESCRIPTION
## Summary

Follow-up from the #95 investigation. Each data file was being parsed **twice** during processing — once inside `generate()` (for metadata) and again in the caller (for CSV conversion / the main table). This parses it **once** and reuses the rows.

- `JsPsychMetadata.generate()` now accepts `data` that is already a parsed array of observations (its docstring already claimed this); when given an array it skips parsing. A pre-parsed caller passes the new `synthesizedSourceRecordId` option so the synthetic-id description is still applied for JSON-Lines.
- The CLI (`processFile`) and the frontend upload step now parse a file a single time and hand the rows to both `generate()` and the Psych-DS CSV builder.

No change to generated metadata or output files — purely CPU/peak-memory savings on large datasets (e.g. multi-MB jsPsych/Tobii exports).

## Subtlety handled

`generate()` strips unnamed (R row-index) columns **in place**, so once the rows are shared they're already clean by the time the CSV is written. The "write the original CSV bytes verbatim" optimization can no longer re-detect the drop from the cleaned rows, so it's now gated on a `csvVerbatimEligible` check taken **before** `generate()` mutates the rows. Regression tests for unnamed-column dropping (both the rename-plan and non-plan paths) cover this.

## Scope note on #95

The investigation found #95's premise — that `extractedArrays` accumulates across *all* files — no longer holds: `generate()` resets the maps per call and both the CLI and frontend write each file's sidecars before the next (the cross-file accumulation was fixed in `b876c2d`, before #95 was filed). The remaining real concern is the **browser holding all converted output at once**, which is a separate, larger question (raised for discussion). This PR ships the one clear, low-risk win.

## Testing

- `npx jest` across `metadata`, `cli`, `frontend`: **622 passing** (the only failures are two pre-existing environment-only ones — a Windows path-separator assertion and a missing optional `node-pty` — both green on CI).
- Added a parse-once regression guard to the CLI suite (`generate()` receives parsed rows, not a string) and updated `DataUpload` tests to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)