### PR TITLE
feat(frontend): stream upload→validate→download via OPFS staging to bound memory (#95)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,8 @@ dist
 .impeccable/
 PRODUCT.md
 dev/smoke-test*/
+
+# Local dev/measurement artifacts (synthetic fixtures, stress inputs, shortcuts; see #95)
+dev/synthetic-dataset/
+dev/stress-test/
+dev/*.lnk

--- a/packages/frontend/scripts/gen-synthetic-dataset.mjs
+++ b/packages/frontend/scripts/gen-synthetic-dataset.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Generates a synthetic jsPsych-style dataset for measuring the in-browser memory profile of the
+// upload → validate → download pipeline (issue #95). Each file is one "subject": a JSON array of
+// trials, where every trial carries a nested array column (`gaze_data`) — the eye-tracking-style
+// payload that drives sidecar-CSV extraction and dominates memory, mirroring the real Tobii case.
+//
+// The output is reproducible from a seed, so the SAME input can be loaded on `main` and on the
+// OPFS branch and the peak-heap numbers compared apples-to-apples.
+//
+// Usage:
+//   node packages/frontend/scripts/gen-synthetic-dataset.mjs [options]
+//
+// Options (all optional; defaults in brackets):
+//   --files N        number of subject files            [20]
+//   --trials M       trials per file                    [400]
+//   --gaze K         gaze samples (array items) / trial [200]
+//   --out DIR        output directory   [./dev/synthetic-dataset]
+//   --seed S         RNG seed for reproducible output    [1]
+//
+// Example — roughly the Tobii scale (~1.6M extracted rows, several hundred MB on disk):
+//   node packages/frontend/scripts/gen-synthetic-dataset.mjs --files 20 --trials 400 --gaze 200
+
+import { mkdir, writeFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  const defaults = { files: 20, trials: 400, gaze: 200, out: './dev/synthetic-dataset', seed: 1 };
+  const opts = { ...defaults };
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i]?.replace(/^--/, '');
+    const val = argv[i + 1];
+    if (key === undefined || val === undefined) continue;
+    if (key === 'out') opts.out = val;
+    else if (key in opts) opts[key] = Number(val);
+    else throw new Error(`Unknown option: --${key}`);
+  }
+  return opts;
+}
+
+// Mulberry32 — a tiny deterministic PRNG so a given seed always yields the same dataset.
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const STIMULI = ['mass', 'count', 'neutral', 'filler'];
+const RESPONSES = ['f', 'j', 'left', 'right'];
+
+function makeTrial(rng, trialIndex, timeElapsed, gazeLen) {
+  const gaze_data = [];
+  for (let s = 0; s < gazeLen; s++) {
+    gaze_data.push({
+      t: Math.round(rng() * 1000),
+      x: +(rng() * 1920).toFixed(1),
+      y: +(rng() * 1080).toFixed(1),
+      validity: rng() > 0.05,
+    });
+  }
+  return {
+    trial_type: 'html-keyboard-response',
+    trial_index: trialIndex,
+    time_elapsed: timeElapsed,
+    stimulus: STIMULI[Math.floor(rng() * STIMULI.length)],
+    response: RESPONSES[Math.floor(rng() * RESPONSES.length)],
+    rt: Math.round(200 + rng() * 1500),
+    correct: rng() > 0.3,
+    gaze_data,
+  };
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const outDir = path.resolve(opts.out);
+  const rng = mulberry32(opts.seed);
+
+  // Fresh directory so stale files from a previous run don't skew the measurement.
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(outDir, { recursive: true });
+
+  let totalBytes = 0;
+  for (let f = 0; f < opts.files; f++) {
+    let timeElapsed = 0;
+    const trials = [];
+    for (let t = 0; t < opts.trials; t++) {
+      timeElapsed += Math.round(300 + rng() * 1800);
+      trials.push(makeTrial(rng, t, timeElapsed, opts.gaze));
+    }
+    const json = JSON.stringify(trials);
+    totalBytes += Buffer.byteLength(json);
+    const name = `subject-${String(f + 1).padStart(2, '0')}_data.json`;
+    await writeFile(path.join(outDir, name), json);
+  }
+
+  const extractedRows = opts.files * opts.trials * opts.gaze;
+  const fmtMB = (b) => (b / 1024 / 1024).toFixed(1);
+  console.log(`Wrote ${opts.files} files to ${outDir}`);
+  console.log(`  ${opts.trials} trials/file, ${opts.gaze} gaze samples/trial (seed ${opts.seed})`);
+  console.log(`  ~${fmtMB(totalBytes)} MB on disk; ~${extractedRows.toLocaleString()} extracted gaze_data rows total`);
+  console.log(`\nUpload this folder in the Data step to measure peak heap during validate/download.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/frontend/src/components/AppShell.tsx
+++ b/packages/frontend/src/components/AppShell.tsx
@@ -40,6 +40,15 @@ const AppShell: React.FC<AppShellProps> = ({ jsPsychMetadata, existingMetadataFi
   );
   const [previewOpen, setPreviewOpen] = useState(false);
 
+  // Discard this session's on-disk staging before tearing the shell down — Start Over throws the
+  // whole project away, so the converted CSVs/raw originals shouldn't linger in OPFS (otherwise
+  // they sit there until the next startup sweep). Fire-and-forget: clear() swallows its own errors
+  // and navigation needn't wait on disk cleanup.
+  const handleStartOver = () => {
+    void dataSession.convertedStore?.clear();
+    onStartOver();
+  };
+
   const completeStep = (stepId: StepId) => {
     const idx = STEPS.findIndex(s => s.id === stepId);
     setCompletedSteps(prev => new Set([...prev, stepId]));
@@ -104,7 +113,7 @@ const AppShell: React.FC<AppShellProps> = ({ jsPsychMetadata, existingMetadataFi
         completedSteps={completedSteps}
         canNavigateTo={canNavigateTo}
         onNavigate={(stepId) => { if (canNavigateTo(stepId)) setCurrentStep(stepId); }}
-        onStartOver={onStartOver}
+        onStartOver={handleStartOver}
       />
       <main className={styles.content}>
         {renderStep()}

--- a/packages/frontend/src/components/AppShell.tsx
+++ b/packages/frontend/src/components/AppShell.tsx
@@ -92,7 +92,7 @@ const AppShell: React.FC<AppShellProps> = ({ jsPsychMetadata, existingMetadataFi
       case 'authors':
         return <Authors jsPsychMetadata={jsPsychMetadata} onComplete={() => completeStep('authors')} />;
       case 'review':
-        return <Review jsPsychMetadata={jsPsychMetadata} dataFiles={dataSession.convertedFiles} />;
+        return <Review jsPsychMetadata={jsPsychMetadata} dataFiles={dataSession.convertedStore} />;
     }
   };
 

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
+import { sweepStaleStagingDirs } from './staging/stagedFileStore'
 import './index.css'
+
+// Reclaim OPFS staging subdirs from previous sessions that closed or crashed before clearing.
+void sweepStaleStagingDirs()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/packages/frontend/src/pages/DataUpload.tsx
+++ b/packages/frontend/src/pages/DataUpload.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import JSZip from 'jszip';
 import JsPsychMetadata, { analyzeJoinKeys, deriveFallbackBase, buildPsychDSDataFiles, isValidPsychDSDataFilename, parseCSV, parseJsonData, PSYCHDS_IGNORE_FILENAME, PSYCHDS_IGNORE_CONTENT } from '@jspsych/metadata';
 import PageHeader from '../components/PageHeader';
+import { createStagedFileStore, type StagedFileStore } from '../staging/stagedFileStore';
 import styles from './DataUpload.module.css';
 
 type JoinKeyCandidate = { column: string; makesUnique: boolean };
@@ -16,12 +17,13 @@ export type DataSession = {
   files: File[];
   fileTexts: Map<string, { content: string; type: string }>;
   /**
-   * Psych-DS `data/` payload built from the uploaded files: dataset-relative path
-   * (e.g. `data/subject-sub01_data.csv`, `data/raw/sub01.json`) → file contents. JSON is
-   * converted to Psych-DS-named CSV here so the validator and the downloadable zip both
-   * see compliant datafiles; without this, JSON uploads validate as MISSING_DATAFILE.
+   * Staged Psych-DS `data/` payload built from the uploaded files (dataset-relative paths such as
+   * `data/subject-sub01_data.csv`, `data/raw/sub01.json`). JSON is converted to Psych-DS-named CSV
+   * here so the validator and the downloadable zip both see compliant datafiles; without this,
+   * JSON uploads validate as MISSING_DATAFILE. Backed by OPFS (on disk) so a large study isn't
+   * held in the heap; null until the first processing run. See {@link StagedFileStore}.
    */
-  convertedFiles: Map<string, string>;
+  convertedStore: StagedFileStore | null;
   joinKeyCandidates: JoinKeyCandidate[];
   joinKeyProblemFile: string;
   selectedKeys: string[];
@@ -31,7 +33,7 @@ export type DataSession = {
 export const emptyDataSession: DataSession = {
   files: [],
   fileTexts: new Map(),
-  convertedFiles: new Map(),
+  convertedStore: null,
   joinKeyCandidates: [],
   joinKeyProblemFile: '',
   selectedKeys: ['trial_index'],
@@ -104,7 +106,7 @@ const DataUpload: React.FC<DataUploadProps> = ({
   const [sourceName, setSourceName] = useState('');
   const [pickError, setPickError] = useState('');
   const [fileTexts, setFileTexts] = useState(session.fileTexts);
-  const [convertedFiles, setConvertedFiles] = useState(session.convertedFiles);
+  const [convertedStore, setConvertedStore] = useState<StagedFileStore | null>(session.convertedStore);
   const [fileStatuses, setFileStatuses] = useState<FileStatus[]>(session.fileStatuses);
   const [joinKeyCandidates, setJoinKeyCandidates] = useState<JoinKeyCandidate[]>(session.joinKeyCandidates);
   const [joinKeyProblemFile, setJoinKeyProblemFile] = useState(session.joinKeyProblemFile);
@@ -119,9 +121,9 @@ const DataUpload: React.FC<DataUploadProps> = ({
   onSessionChangeRef.current = onSessionChange;
   useEffect(() => {
     onSessionChangeRef.current({
-      files, fileTexts, convertedFiles, joinKeyCandidates, joinKeyProblemFile, selectedKeys: committedKeys, fileStatuses,
+      files, fileTexts, convertedStore, joinKeyCandidates, joinKeyProblemFile, selectedKeys: committedKeys, fileStatuses,
     });
-  }, [files, fileTexts, convertedFiles, joinKeyCandidates, joinKeyProblemFile, committedKeys, fileStatuses]);
+  }, [files, fileTexts, convertedStore, joinKeyCandidates, joinKeyProblemFile, committedKeys, fileStatuses]);
 
   useEffect(() => {
     if (inputRef.current) (inputRef.current as any).webkitdirectory = true; // not in TS lib
@@ -239,10 +241,13 @@ const DataUpload: React.FC<DataUploadProps> = ({
     const update = (i: number, patch: Partial<FileStatus>) =>
       setFileStatuses(prev => prev.map((s, idx) => idx === i ? { ...s, ...patch } : s));
 
-    // Psych-DS `data/` payload built alongside metadata generation. The name sets are shared
-    // across all files so converted CSVs are disambiguated against the whole output directory
-    // (mirrors the CLI's processDirectory), and `data/raw/` is flat so originals must be too.
-    const converted = new Map<string, string>();
+    // Psych-DS `data/` payload built alongside metadata generation, staged to disk (OPFS) as each
+    // file is produced so the whole study is never resident in the heap at once. The name sets are
+    // shared across all files so converted CSVs are disambiguated against the whole output
+    // directory (mirrors the CLI's processDirectory), and `data/raw/` is flat so originals too.
+    // Reuse the existing store across re-processing runs, clearing stale output first.
+    const store = convertedStore ?? createStagedFileStore();
+    await store.clear();
     const usedArrayFilenames = new Set<string>();
     const usedRawFilenames = new Set<string>();
 
@@ -303,13 +308,13 @@ const DataUpload: React.FC<DataUploadProps> = ({
           joinKeys: jsPsychMetadata.getArrayJoinKeys(),
           usedArrayFilenames,
         });
-        for (const f of built) converted.set(`data/${f.filename}`, f.content);
+        for (const f of built) await store.write(`data/${f.filename}`, f.content);
 
         // Preserve the original JSON under data/raw/ (CSV inputs are already tabular).
         if (type === 'json') {
           const rawName = disambiguateFlatFilename(file.name, usedRawFilenames);
           usedRawFilenames.add(rawName);
-          converted.set(`data/raw/${rawName}`, content);
+          await store.write(`data/raw/${rawName}`, content);
         }
 
         update(i, { status: 'success' });
@@ -321,10 +326,10 @@ const DataUpload: React.FC<DataUploadProps> = ({
     // When we preserved raw originals, tell the validator to skip data/raw/ so they don't
     // surface as FILE_NOT_CHECKED (shared definition with the CLI in @jspsych/metadata).
     if (usedRawFilenames.size > 0) {
-      converted.set(PSYCHDS_IGNORE_FILENAME, PSYCHDS_IGNORE_CONTENT);
+      await store.write(PSYCHDS_IGNORE_FILENAME, PSYCHDS_IGNORE_CONTENT);
     }
 
-    setConvertedFiles(converted);
+    setConvertedStore(store);
     setPhase('done');
   };
 

--- a/packages/frontend/src/pages/Review.tsx
+++ b/packages/frontend/src/pages/Review.tsx
@@ -1,19 +1,21 @@
 import { useState, useMemo } from 'react';
-import JSZip from 'jszip';
 import JsPsychMetadata from '@jspsych/metadata';
 import JsonViewer from '../components/JsonViewer';
 import PageHeader from '../components/PageHeader';
 import { DATASET_DESCRIPTION_FILENAME as FILENAME } from '../datasetLayout';
+import { buildDatasetZipBlob } from '../staging/datasetZip';
+import type { StagedFileStore } from '../staging/stagedFileStore';
 import type { PsychDSValidationResult } from '../validation/validatePsychDS';
 import styles from './Review.module.css';
 
 interface ReviewProps {
   jsPsychMetadata: JsPsychMetadata;
   /**
-   * Psych-DS `data/` payload (dataset-relative path → contents, e.g. `data/subject-sub01_data.csv`),
-   * already converted to compliant CSV by the upload step. Drives both validation and the zip.
+   * Staged Psych-DS `data/` payload (dataset-relative paths, e.g. `data/subject-sub01_data.csv`),
+   * already converted to compliant CSV by the upload step and held on disk (OPFS). Read one file
+   * at a time to drive both validation and the zip. Null/absent when no data was uploaded.
    */
-  dataFiles?: Map<string, string>;
+  dataFiles?: StagedFileStore | null;
 }
 
 function blobDownload(blob: Blob, filename: string) {
@@ -50,9 +52,8 @@ const Review: React.FC<ReviewProps> = ({ jsPsychMetadata, dataFiles }) => {
     return name?.trim() || 'dataset';
   }, []);
 
-  // Converted Psych-DS data/ payload (paths already include `data/`); drives validation + zip.
-  const dataPayload = useMemo(() => dataFiles ?? new Map<string, string>(), [dataFiles]);
-  const hasDataFiles = dataPayload.size > 0;
+  // Staged Psych-DS data/ payload (paths already include `data/`); drives validation + zip.
+  const hasDataFiles = (dataFiles?.paths().length ?? 0) > 0;
 
   const handleDownload = async () => {
     if ('showSaveFilePicker' in window) {
@@ -77,14 +78,8 @@ const Review: React.FC<ReviewProps> = ({ jsPsychMetadata, dataFiles }) => {
   };
 
   const handleDownloadZip = async () => {
-    const zip = new JSZip();
-    zip.file(FILENAME, metadataJson);
-    for (const [path, content] of dataPayload) {
-      zip.file(path, content); // path already includes the `data/` prefix
-    }
-    zip.file('README.md', `# ${projectName}\nHuman-readable description of the project and dataset.`);
-    zip.file('CHANGES.md', 'For version tracking — if the dataset is updated after being uploaded/shared, changes (with human-readable descriptions) may be recorded here.');
-    const blob = await zip.generateAsync({ type: 'blob', compression: 'DEFLATE' });
+    // Built from the staged store, reading one file at a time (see buildDatasetZipBlob).
+    const blob = await buildDatasetZipBlob({ metadataJson, projectName, dataFiles: dataFiles ?? undefined });
     blobDownload(blob, `${projectName}.zip`);
     setZipped(true);
   };
@@ -95,7 +90,7 @@ const Review: React.FC<ReviewProps> = ({ jsPsychMetadata, dataFiles }) => {
     try {
       // Lazy-loaded so the ~260 KB validator bundle stays out of the initial load.
       const { validatePsychDS } = await import('../validation/validatePsychDS');
-      const result = await validatePsychDS(metadataJson, dataPayload);
+      const result = await validatePsychDS(metadataJson, dataFiles ?? undefined);
       setValResult(result);
       setValStatus('done');
     } catch (err) {

--- a/packages/frontend/src/staging/datasetZip.ts
+++ b/packages/frontend/src/staging/datasetZip.ts
@@ -1,0 +1,48 @@
+// Builds the downloadable Psych-DS dataset zip from the staged file store.
+//
+// Reads each data file from the store lazily (one at a time) and adds it to the archive, so the
+// whole converted payload is never held in the JS heap at once — only the file currently being
+// compressed. JSZip's input files are read during generateAsync(); pairing it with the OPFS-backed
+// store (disk-backed Blobs) keeps the input side off the heap. If profiling later shows the output
+// Blob itself is the bottleneck, this is the seam to swap JSZip for a streaming zip (e.g.
+// client-zip) writing to a disk-backed sink — callers only depend on buildDatasetZipBlob.
+
+import JSZip from 'jszip';
+import { DATASET_DESCRIPTION_FILENAME } from '../datasetLayout';
+import type { DatasetFileSource } from './stagedFileStore';
+
+const readmeContents = (projectName: string): string =>
+  `# ${projectName}\nHuman-readable description of the project and dataset.`;
+
+const CHANGES_CONTENTS =
+  'For version tracking — if the dataset is updated after being uploaded/shared, changes (with human-readable descriptions) may be recorded here.';
+
+export interface BuildDatasetZipOptions {
+  /** Serialized dataset_description.json (written at the archive root). */
+  metadataJson: string;
+  /** Used for the README heading; not the zip filename. */
+  projectName: string;
+  /** Staged `data/` payload (paths already include the `data/` prefix). Omit for metadata-only. */
+  dataFiles?: DatasetFileSource;
+}
+
+/**
+ * Assembles dataset_description.json + the staged data files + README/CHANGES into a single zip
+ * Blob, ready to hand to a download. Data files are pulled from the source one at a time.
+ */
+export async function buildDatasetZipBlob({
+  metadataJson,
+  projectName,
+  dataFiles,
+}: BuildDatasetZipOptions): Promise<Blob> {
+  const zip = new JSZip();
+  zip.file(DATASET_DESCRIPTION_FILENAME, metadataJson);
+  if (dataFiles) {
+    for await (const [path, blob] of dataFiles.entries()) {
+      zip.file(path, blob); // path already includes the `data/` prefix
+    }
+  }
+  zip.file('README.md', readmeContents(projectName));
+  zip.file('CHANGES.md', CHANGES_CONTENTS);
+  return zip.generateAsync({ type: 'blob', compression: 'DEFLATE' });
+}

--- a/packages/frontend/src/staging/stagedFileStore.ts
+++ b/packages/frontend/src/staging/stagedFileStore.ts
@@ -92,6 +92,8 @@ class OpfsFileStore implements StagedFileStore {
   readonly backend = 'opfs' as const;
   // Real dataset-relative paths in insertion order; the on-disk name is encodePath(path).
   private readonly index: string[] = [];
+  // Set mirror of index for O(1) has() and write() dedup checks.
+  private readonly indexSet = new Set<string>();
   // This store's own subdir of STAGING_ROOT — isolates it from other tabs and is the unit clear()
   // removes. The timestamp prefix lets sweepStaleStagingDirs() tell live sessions from dead ones.
   private readonly sessionDir = newSessionDirName();
@@ -120,11 +122,11 @@ class OpfsFileStore implements StagedFileStore {
     } finally {
       await writable.close();
     }
-    if (!this.index.includes(path)) this.index.push(path);
+    if (!this.indexSet.has(path)) { this.index.push(path); this.indexSet.add(path); }
   }
 
   has(path: string): boolean {
-    return this.index.includes(path);
+    return this.indexSet.has(path);
   }
 
   paths(): string[] {
@@ -155,6 +157,7 @@ class OpfsFileStore implements StagedFileStore {
     }
     this.dirHandle = null;
     this.index.length = 0;
+    this.indexSet.clear();
   }
 }
 

--- a/packages/frontend/src/staging/stagedFileStore.ts
+++ b/packages/frontend/src/staging/stagedFileStore.ts
@@ -19,7 +19,16 @@
 
 export type StagedFileStoreBackend = 'opfs' | 'memory';
 
-export interface StagedFileStore {
+/**
+ * A lazy source of dataset-relative files (path -> Blob), read one at a time. Both the validator
+ * (tree building) and the zip builder consume this, so neither needs the whole payload in the
+ * heap at once. {@link StagedFileStore} is the production implementation.
+ */
+export interface DatasetFileSource {
+  entries(): AsyncIterableIterator<[string, Blob]>;
+}
+
+export interface StagedFileStore extends DatasetFileSource {
   /** Backend actually in use, for diagnostics/measurement. */
   readonly backend: StagedFileStoreBackend;
   /** Stage one file. `content` may be a string or a Blob; large content should be a Blob. */

--- a/packages/frontend/src/staging/stagedFileStore.ts
+++ b/packages/frontend/src/staging/stagedFileStore.ts
@@ -12,10 +12,13 @@
 // save-dialog permission. When OPFS is unavailable (older browsers, non-secure contexts, the
 // jsdom test env) it transparently falls back to an in-memory Map — same API, no disk benefit.
 //
-// The on-disk layout is flat: dataset-relative paths (e.g. "data/raw/sub01.json") are encoded
+// Each store instance owns a per-session subdirectory of STAGING_ROOT (a timestamped, random
+// name), so two tabs of the same origin never read or clear each other's staged files. Within
+// that subdir the layout is flat: dataset-relative paths (e.g. "data/raw/sub01.json") are encoded
 // into single OPFS filenames, and the real paths are kept in a small in-memory index (just
 // strings — kilobytes even for thousands of files). entries() reads files lazily so nothing is
-// materialized until the consumer pulls it.
+// materialized until the consumer pulls it. Subdirectories left behind by sessions that closed
+// without clearing are reclaimed by sweepStaleStagingDirs(), called once at app startup.
 
 export type StagedFileStoreBackend = 'opfs' | 'memory';
 
@@ -45,8 +48,15 @@ export interface StagedFileStore extends DatasetFileSource {
   clear(): Promise<void>;
 }
 
-/** Name of the OPFS subdirectory the store scopes its files to. */
-const STAGING_DIR = 'psychds-staging';
+/** Name of the OPFS directory that all staging sessions live under. */
+const STAGING_ROOT = 'psychds-staging';
+
+/**
+ * Per-session subdirs older than this are reclaimed by {@link sweepStaleStagingDirs}. Long enough
+ * that a session left open for a normal working span is never swept out from under itself; short
+ * enough that disk from a crashed or closed tab is reclaimed on a later visit.
+ */
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
 
 /** True when the Origin Private File System is usable in this environment. */
 export function opfsAvailable(): boolean {
@@ -61,14 +71,44 @@ export function opfsAvailable(): boolean {
 // so encode it reversibly. encodeURIComponent also escapes characters some filesystems dislike.
 const encodePath = (path: string): string => encodeURIComponent(path);
 
+// Per-session subdir name: a base36 timestamp prefix (so its age is recoverable for the stale
+// sweep) followed by random entropy (so two tabs created in the same millisecond never collide).
+function newSessionDirName(): string {
+  const ts = Date.now().toString(36);
+  const rand =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID().slice(0, 8)
+      : Math.floor(Math.random() * 0x1_0000_0000).toString(36);
+  return `${ts}-${rand}`;
+}
+
+// Age in ms of a session subdir from its name, or null if the name isn't one we minted.
+function sessionDirAgeMs(name: string, now: number): number | null {
+  const ts = parseInt(name.split('-')[0] ?? '', 36);
+  return Number.isFinite(ts) && ts > 0 ? now - ts : null;
+}
+
 class OpfsFileStore implements StagedFileStore {
   readonly backend = 'opfs' as const;
   // Real dataset-relative paths in insertion order; the on-disk name is encodePath(path).
   private readonly index: string[] = [];
+  // This store's own subdir of STAGING_ROOT — isolates it from other tabs and is the unit clear()
+  // removes. The timestamp prefix lets sweepStaleStagingDirs() tell live sessions from dead ones.
+  private readonly sessionDir = newSessionDirName();
+  // Resolved lazily and memoised: the directory handle is looked up once, not on every read/write.
+  private dirHandle: FileSystemDirectoryHandle | null = null;
+
+  private async stagingRoot(): Promise<FileSystemDirectoryHandle> {
+    const root = await navigator.storage.getDirectory();
+    return root.getDirectoryHandle(STAGING_ROOT, { create: true });
+  }
 
   private async dir(): Promise<FileSystemDirectoryHandle> {
-    const root = await navigator.storage.getDirectory();
-    return root.getDirectoryHandle(STAGING_DIR, { create: true });
+    if (!this.dirHandle) {
+      const root = await this.stagingRoot();
+      this.dirHandle = await root.getDirectoryHandle(this.sessionDir, { create: true });
+    }
+    return this.dirHandle;
   }
 
   async write(path: string, content: string | Blob): Promise<void> {
@@ -104,13 +144,16 @@ class OpfsFileStore implements StagedFileStore {
   }
 
   async clear(): Promise<void> {
-    const root = await navigator.storage.getDirectory();
-    // removeEntry recurses with { recursive: true }; ignore "not found" so clear() is idempotent.
+    // Remove only this session's subdir, never the shared root — a concurrent tab keeps its own.
+    // Ignore "not found" so clear() is idempotent; drop the memoised handle so the next write()
+    // recreates the (now-deleted) subdir.
     try {
-      await root.removeEntry(STAGING_DIR, { recursive: true });
+      const root = await this.stagingRoot();
+      await root.removeEntry(this.sessionDir, { recursive: true });
     } catch {
-      /* directory may not exist yet — nothing to clear */
+      /* this session's dir may not exist yet — nothing to clear */
     }
+    this.dirHandle = null;
     this.index.length = 0;
   }
 }
@@ -145,6 +188,48 @@ class MemoryFileStore implements StagedFileStore {
 
   async clear(): Promise<void> {
     this.files.clear();
+  }
+}
+
+/**
+ * Reclaim staging subdirectories left behind by earlier sessions (a tab closed or crashed before
+ * clear() ran). Only entries older than `maxAgeMs` are removed, so a concurrently-open tab's fresh
+ * session is never deleted; anything that isn't a recognisable, recent session subdir (stray files,
+ * pre-subdir-layout leftovers, unparseable names) is reclaimed too. Best-effort — a missing root or
+ * a per-entry failure (e.g. another tab holding the dir) is ignored. Call once at app startup.
+ */
+export async function sweepStaleStagingDirs(maxAgeMs: number = SESSION_TTL_MS): Promise<void> {
+  if (!opfsAvailable()) return;
+  const now = Date.now();
+
+  let staging: FileSystemDirectoryHandle;
+  try {
+    const root = await navigator.storage.getDirectory();
+    staging = await root.getDirectoryHandle(STAGING_ROOT);
+  } catch {
+    return; // nothing has been staged yet
+  }
+
+  // Collect first, then remove — don't mutate the directory while iterating it.
+  const stale: string[] = [];
+  try {
+    const dir = staging as unknown as {
+      entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+    };
+    for await (const [name, handle] of dir.entries()) {
+      const age = handle.kind === 'directory' ? sessionDirAgeMs(name, now) : null;
+      if (age === null || age > maxAgeMs) stale.push(name);
+    }
+  } catch {
+    return;
+  }
+
+  for (const name of stale) {
+    try {
+      await staging.removeEntry(name, { recursive: true });
+    } catch {
+      /* already gone, or held by another tab — leave it */
+    }
   }
 }
 

--- a/packages/frontend/src/staging/stagedFileStore.ts
+++ b/packages/frontend/src/staging/stagedFileStore.ts
@@ -1,0 +1,148 @@
+// Staging store for the converted Psych-DS payload.
+//
+// Why this exists: the upload → validate → download pipeline used to hold every converted CSV
+// (and every preserved raw original) in the JS heap at once as strings, then hand all of it to
+// the validator (as Blobs) and to JSZip simultaneously. For a large multi-file study that is
+// several full copies of the whole dataset resident at the same time, which OOMs the tab.
+//
+// This store keeps each file's bytes on disk via the Origin Private File System (OPFS) instead
+// of the heap. Callers write each file as it's produced and later read them back one at a time
+// (for validation and for the zip), so peak heap is ~one file's working set rather than the
+// whole study. OPFS is available in current Chromium, Firefox and Safari and needs no
+// save-dialog permission. When OPFS is unavailable (older browsers, non-secure contexts, the
+// jsdom test env) it transparently falls back to an in-memory Map — same API, no disk benefit.
+//
+// The on-disk layout is flat: dataset-relative paths (e.g. "data/raw/sub01.json") are encoded
+// into single OPFS filenames, and the real paths are kept in a small in-memory index (just
+// strings — kilobytes even for thousands of files). entries() reads files lazily so nothing is
+// materialized until the consumer pulls it.
+
+export type StagedFileStoreBackend = 'opfs' | 'memory';
+
+export interface StagedFileStore {
+  /** Backend actually in use, for diagnostics/measurement. */
+  readonly backend: StagedFileStoreBackend;
+  /** Stage one file. `content` may be a string or a Blob; large content should be a Blob. */
+  write(path: string, content: string | Blob): Promise<void>;
+  /** Whether a path has been staged. */
+  has(path: string): boolean;
+  /** All staged dataset-relative paths, in insertion order. */
+  paths(): string[];
+  /** Read one staged file back as a (disk-backed, on OPFS) Blob. */
+  read(path: string): Promise<Blob>;
+  /** Lazily iterate every staged file as [path, Blob], reading one at a time. */
+  entries(): AsyncIterableIterator<[string, Blob]>;
+  /** Remove every staged file and reset the index. */
+  clear(): Promise<void>;
+}
+
+/** Name of the OPFS subdirectory the store scopes its files to. */
+const STAGING_DIR = 'psychds-staging';
+
+/** True when the Origin Private File System is usable in this environment. */
+export function opfsAvailable(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    !!navigator.storage &&
+    typeof navigator.storage.getDirectory === 'function'
+  );
+}
+
+// A path can't be an OPFS filename verbatim ("/" is the only forbidden character in practice),
+// so encode it reversibly. encodeURIComponent also escapes characters some filesystems dislike.
+const encodePath = (path: string): string => encodeURIComponent(path);
+
+class OpfsFileStore implements StagedFileStore {
+  readonly backend = 'opfs' as const;
+  // Real dataset-relative paths in insertion order; the on-disk name is encodePath(path).
+  private readonly index: string[] = [];
+
+  private async dir(): Promise<FileSystemDirectoryHandle> {
+    const root = await navigator.storage.getDirectory();
+    return root.getDirectoryHandle(STAGING_DIR, { create: true });
+  }
+
+  async write(path: string, content: string | Blob): Promise<void> {
+    const dir = await this.dir();
+    const handle = await dir.getFileHandle(encodePath(path), { create: true });
+    const writable = await handle.createWritable();
+    try {
+      await writable.write(content);
+    } finally {
+      await writable.close();
+    }
+    if (!this.index.includes(path)) this.index.push(path);
+  }
+
+  has(path: string): boolean {
+    return this.index.includes(path);
+  }
+
+  paths(): string[] {
+    return [...this.index];
+  }
+
+  async read(path: string): Promise<Blob> {
+    const dir = await this.dir();
+    const handle = await dir.getFileHandle(encodePath(path));
+    return handle.getFile(); // a File is a disk-backed Blob — not pulled into the heap until read
+  }
+
+  async *entries(): AsyncIterableIterator<[string, Blob]> {
+    for (const path of this.index) {
+      yield [path, await this.read(path)];
+    }
+  }
+
+  async clear(): Promise<void> {
+    const root = await navigator.storage.getDirectory();
+    // removeEntry recurses with { recursive: true }; ignore "not found" so clear() is idempotent.
+    try {
+      await root.removeEntry(STAGING_DIR, { recursive: true });
+    } catch {
+      /* directory may not exist yet — nothing to clear */
+    }
+    this.index.length = 0;
+  }
+}
+
+class MemoryFileStore implements StagedFileStore {
+  readonly backend = 'memory' as const;
+  private readonly files = new Map<string, Blob>();
+
+  async write(path: string, content: string | Blob): Promise<void> {
+    this.files.set(path, content instanceof Blob ? content : new Blob([content]));
+  }
+
+  has(path: string): boolean {
+    return this.files.has(path);
+  }
+
+  paths(): string[] {
+    return [...this.files.keys()];
+  }
+
+  async read(path: string): Promise<Blob> {
+    const blob = this.files.get(path);
+    if (!blob) throw new Error(`No staged file at "${path}".`);
+    return blob;
+  }
+
+  async *entries(): AsyncIterableIterator<[string, Blob]> {
+    for (const [path, blob] of this.files) {
+      yield [path, blob];
+    }
+  }
+
+  async clear(): Promise<void> {
+    this.files.clear();
+  }
+}
+
+/**
+ * Creates a staging store, preferring OPFS (on-disk, bounded heap) and falling back to an
+ * in-memory store when OPFS isn't available. Pass `forceMemory` to opt out of OPFS (e.g. tests).
+ */
+export function createStagedFileStore(opts: { forceMemory?: boolean } = {}): StagedFileStore {
+  return !opts.forceMemory && opfsAvailable() ? new OpfsFileStore() : new MemoryFileStore();
+}

--- a/packages/frontend/src/validation/validatePsychDS.ts
+++ b/packages/frontend/src/validation/validatePsychDS.ts
@@ -5,6 +5,7 @@ import {
   type PsychDSValidationOutput,
 } from 'psychds-validator/web/psychds-validator.js';
 import { DATASET_DESCRIPTION_FILENAME as FILENAME } from '../datasetLayout';
+import type { DatasetFileSource } from '../staging/stagedFileStore';
 
 export interface ValidationIssue {
   key: string;
@@ -38,7 +39,7 @@ function ensureJsonldGlobal() {
 }
 
 /** Inserts a `/`-separated path into the nested file-tree dict, creating dirs. */
-function insertFile(tree: WebFileTree, path: string, content: string) {
+function insertFile(tree: WebFileTree, path: string, file: Blob) {
   const segments = path.split('/').filter(Boolean);
   const filename = segments.pop();
   if (!filename) return;
@@ -52,20 +53,21 @@ function insertFile(tree: WebFileTree, path: string, content: string) {
     }
     dir = node.contents;
   }
-  dir[filename] = { type: 'file', file: new Blob([content]) };
+  dir[filename] = { type: 'file', file };
 }
 
-function buildFileTree(
+async function buildFileTree(
   metadataJson: string,
-  dataFiles?: Map<string, string>,
-): WebFileTree {
+  dataFiles?: DatasetFileSource,
+): Promise<WebFileTree> {
   const tree: WebFileTree = {
     [FILENAME]: { type: 'file', file: new Blob([metadataJson]) },
   };
   if (dataFiles) {
-    // Keys are already dataset-relative paths (e.g. `data/subject-sub01_data.csv`), inserted as-is.
-    for (const [path, content] of dataFiles) {
-      insertFile(tree, path, content);
+    // Keys are already dataset-relative paths (e.g. `data/subject-sub01_data.csv`). Pulled one at
+    // a time so only the current file's Blob is touched, not the whole payload at once.
+    for await (const [path, file] of dataFiles.entries()) {
+      insertFile(tree, path, file);
     }
   }
   return tree;
@@ -77,16 +79,16 @@ function buildFileTree(
  * fetches the Psych-DS schema and schema.org context at runtime.
  *
  * @param metadataJson  Serialized dataset_description.json.
- * @param dataFiles     Psych-DS `data/` payload: dataset-relative path
- *                      (e.g. `data/subject-sub01_data.csv`) -> file contents.
+ * @param dataFiles     Lazy source of the Psych-DS `data/` payload: dataset-relative path
+ *                      (e.g. `data/subject-sub01_data.csv`) -> file Blob, read one at a time.
  */
 export async function validatePsychDS(
   metadataJson: string,
-  dataFiles?: Map<string, string>,
+  dataFiles?: DatasetFileSource,
 ): Promise<PsychDSValidationResult> {
   ensureJsonldGlobal();
 
-  const tree = buildFileTree(metadataJson, dataFiles);
+  const tree = await buildFileTree(metadataJson, dataFiles);
 
   let output: PsychDSValidationOutput;
   try {

--- a/packages/frontend/tests/AppShell.test.tsx
+++ b/packages/frontend/tests/AppShell.test.tsx
@@ -38,12 +38,22 @@ jest.mock("../src/pages/ProjectInfo", () => ({
   OPTIONAL_FIELDS: [],
 }));
 
+// A fake staged store the DataUpload stub can push into the session, so Start Over cleanup can be
+// asserted. The `mock` prefix lets the hoisted jest.mock factory reference it (jest rule).
+const mockStagedClear = jest.fn();
+const mockStagedStore = { clear: mockStagedClear } as any;
+
 jest.mock("../src/pages/DataUpload", () => ({
   __esModule: true,
-  default: ({ onComplete }: any) => (
+  default: ({ onComplete, onSessionChange }: any) => (
     <div>
       <span>DataUpload page</span>
       <button onClick={onComplete}>Complete DataUpload</button>
+      <button
+        onClick={() => onSessionChange({ files: [], fileTexts: new Map(), convertedStore: mockStagedStore })}
+      >
+        Stage data
+      </button>
     </div>
   ),
   emptyDataSession: { fileTexts: [], files: [] },
@@ -86,6 +96,7 @@ let onStartOver: jest.Mock;
 beforeEach(() => {
   meta = makeMeta();
   onStartOver = jest.fn();
+  mockStagedClear.mockClear();
 });
 
 describe("AppShell", () => {
@@ -230,6 +241,24 @@ describe("AppShell", () => {
     test("Sidebar 'Start over' calls the onStartOver prop", async () => {
       render(<AppShell jsPsychMetadata={meta} onStartOver={onStartOver} />);
       await userEvent.click(screen.getByRole("button", { name: "Start over" }));
+      expect(onStartOver).toHaveBeenCalledTimes(1);
+    });
+
+    test("Start over clears the session's staged file store before bubbling up", async () => {
+      render(<AppShell jsPsychMetadata={meta} onStartOver={onStartOver} />);
+      await userEvent.click(screen.getByRole("button", { name: "Complete ProjectInfo" }));
+      await userEvent.click(screen.getByRole("button", { name: "Stage data" })); // session now holds a store
+      await userEvent.click(screen.getByRole("button", { name: "Start over" }));
+
+      expect(mockStagedClear).toHaveBeenCalledTimes(1);
+      expect(onStartOver).toHaveBeenCalledTimes(1);
+    });
+
+    test("Start over is a no-op for the store when nothing was staged", async () => {
+      render(<AppShell jsPsychMetadata={meta} onStartOver={onStartOver} />);
+      await userEvent.click(screen.getByRole("button", { name: "Start over" }));
+
+      expect(mockStagedClear).not.toHaveBeenCalled();
       expect(onStartOver).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/frontend/tests/Review.test.tsx
+++ b/packages/frontend/tests/Review.test.tsx
@@ -3,6 +3,15 @@ import userEvent from "@testing-library/user-event";
 import JsPsychMetadata from "@jspsych/metadata";
 import Review from "../src/pages/Review";
 import { validatePsychDS } from "../src/validation/validatePsychDS";
+import { createStagedFileStore, type StagedFileStore } from "../src/staging/stagedFileStore";
+
+// The converted Psych-DS payload now lives in a staged store (OPFS-backed in the browser,
+// in-memory here). Build one pre-populated for tests that exercise the data-files path.
+async function storeWith(entries: Array<[string, string]>): Promise<StagedFileStore> {
+  const store = createStagedFileStore({ forceMemory: true });
+  for (const [path, content] of entries) await store.write(path, content);
+  return store;
+}
 
 // Review lazy-loads the validator wrapper on the first Validate click; mock it
 // so tests exercise the UI states without the real (network-bound) validator.
@@ -39,9 +48,9 @@ describe("Review", () => {
     expect(screen.queryByRole("button", { name: /\.zip/ })).not.toBeInTheDocument();
   });
 
-  test("offers a zip download named after the project when data files exist", () => {
+  test("offers a zip download named after the project when data files exist", async () => {
     // dataFiles is the converted Psych-DS payload (path -> contents), already built upstream.
-    const dataFiles = new Map([["data/subject-sub01_data.csv", "a,b\n1,2"]]);
+    const dataFiles = await storeWith([["data/subject-sub01_data.csv", "a,b\n1,2"]]);
     render(<Review jsPsychMetadata={makeMetadata()} dataFiles={dataFiles} />);
     expect(
       screen.getByRole("button", { name: "Download my-project.zip" }),
@@ -51,8 +60,8 @@ describe("Review", () => {
     ).toBeInTheDocument();
   });
 
-  test("offers only the single-file save when the converted payload is empty", () => {
-    render(<Review jsPsychMetadata={makeMetadata()} dataFiles={new Map()} />);
+  test("offers only the single-file save when the converted payload is empty", async () => {
+    render(<Review jsPsychMetadata={makeMetadata()} dataFiles={await storeWith([])} />);
     expect(
       screen.getByRole("button", { name: "Save dataset_description.json" }),
     ).toBeInTheDocument();
@@ -69,7 +78,7 @@ describe("Review", () => {
   });
 
   test("downloading the zip bundles metadata plus data files and confirms", async () => {
-    const dataFiles = new Map([["data/subject-sub01_data.csv", "a,b\n1,2"]]);
+    const dataFiles = await storeWith([["data/subject-sub01_data.csv", "a,b\n1,2"]]);
     render(<Review jsPsychMetadata={makeMetadata()} dataFiles={dataFiles} />);
     await userEvent.click(screen.getByRole("button", { name: "Download my-project.zip" }));
 
@@ -77,16 +86,16 @@ describe("Review", () => {
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
   });
 
-  test("validates the metadata and passes the converted data payload through", async () => {
+  test("validates the metadata and passes the staged data store through", async () => {
     mockValidate.mockResolvedValue({ valid: true, errors: [], warnings: [] });
-    const dataFiles = new Map([["data/subject-sub01_data.csv", "a,b\n1,2"]]);
+    const dataFiles = await storeWith([["data/subject-sub01_data.csv", "a,b\n1,2"]]);
     render(<Review jsPsychMetadata={makeMetadata()} dataFiles={dataFiles} />);
     await userEvent.click(screen.getByRole("button", { name: "Validate dataset" }));
 
     expect(await screen.findByText("✓ Valid Psych-DS dataset")).toBeInTheDocument();
     expect(mockValidate).toHaveBeenCalledWith(
       expect.stringContaining('"my-project"'),
-      new Map([["data/subject-sub01_data.csv", "a,b\n1,2"]]),
+      dataFiles,
     );
     // Button switches to re-validate after a run.
     expect(screen.getByRole("button", { name: "Re-validate" })).toBeInTheDocument();
@@ -127,7 +136,7 @@ describe("Review", () => {
         { key: "MISSING_CHANGES_DOC", reason: "include a CHANGES", evidence: [] },
       ],
     });
-    const dataFiles = new Map([["data/subject-sub01_data.csv", "a,b\n1,2"]]);
+    const dataFiles = await storeWith([["data/subject-sub01_data.csv", "a,b\n1,2"]]);
     render(<Review jsPsychMetadata={makeMetadata()} dataFiles={dataFiles} />);
     await userEvent.click(screen.getByRole("button", { name: "Validate dataset" }));
 

--- a/packages/frontend/tests/dataProcessing.stress.test.ts
+++ b/packages/frontend/tests/dataProcessing.stress.test.ts
@@ -7,6 +7,7 @@
 import JsPsychMetadata from "@jspsych/metadata";
 import { validateWeb } from "psychds-validator/web/psychds-validator.js";
 import { validatePsychDS } from "../src/validation/validatePsychDS";
+import { createStagedFileStore } from "../src/staging/stagedFileStore";
 import { validatorOutput } from "./helpers";
 
 const mockValidateWeb = validateWeb as jest.Mock;
@@ -187,9 +188,11 @@ describe("Smoke-test-2 regression: VARIABLE_MISSING_FROM_CSV_COLUMNS", () => {
       ]),
     );
 
-    const dataFiles = new Map([
-      ["experiment/subject-01_data.csv", "trial_type,trial_index,time_elapsed,stimulus,response,rt,correct\nhtml-keyboard-response,0,812,+,null,null,null"],
-    ]);
+    const dataFiles = createStagedFileStore({ forceMemory: true });
+    await dataFiles.write(
+      "experiment/subject-01_data.csv",
+      "trial_type,trial_index,time_elapsed,stimulus,response,rt,correct\nhtml-keyboard-response,0,812,+,null,null,null",
+    );
 
     const result = await validatePsychDS("{}", dataFiles);
 

--- a/packages/frontend/tests/stagedFileStore.test.ts
+++ b/packages/frontend/tests/stagedFileStore.test.ts
@@ -1,0 +1,139 @@
+import {
+  createStagedFileStore,
+  opfsAvailable,
+  type StagedFileStore,
+} from "../src/staging/stagedFileStore";
+
+// jsdom has no Blob.text(); read through FileReader (matches validatePsychDS.test.ts's helper).
+function blobText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+async function collect(store: StagedFileStore): Promise<Array<[string, string]>> {
+  const out: Array<[string, string]> = [];
+  for await (const [path, blob] of store.entries()) out.push([path, await blobText(blob)]);
+  return out;
+}
+
+// ── Minimal in-memory fake of the OPFS handles the store touches ──────────────
+// Mirrors the navigator.storage.getDirectory() surface: nested directory handles, file handles
+// with createWritable()/getFile(), and recursive removeEntry().
+function installFakeOpfs() {
+  class FakeFileHandle {
+    constructor(private store: Map<string, Blob>, private key: string) {}
+    async createWritable() {
+      const parts: Array<string | Blob> = [];
+      const store = this.store;
+      const key = this.key;
+      return {
+        async write(chunk: string | Blob) { parts.push(chunk); },
+        async close() { store.set(key, new Blob(parts)); },
+      };
+    }
+    async getFile(): Promise<Blob> {
+      const blob = this.store.get(this.key);
+      if (!blob) throw new DOMException("NotFound", "NotFoundError");
+      return blob;
+    }
+  }
+  class FakeDirHandle {
+    files = new Map<string, Blob>();
+    dirs = new Map<string, FakeDirHandle>();
+    async getDirectoryHandle(name: string, opts?: { create?: boolean }) {
+      let d = this.dirs.get(name);
+      if (!d) {
+        if (!opts?.create) throw new DOMException("NotFound", "NotFoundError");
+        d = new FakeDirHandle();
+        this.dirs.set(name, d);
+      }
+      return d;
+    }
+    async getFileHandle(name: string, opts?: { create?: boolean }) {
+      if (!this.files.has(name)) {
+        if (!opts?.create) throw new DOMException("NotFound", "NotFoundError");
+        this.files.set(name, new Blob([]));
+      }
+      return new FakeFileHandle(this.files, name);
+    }
+    async removeEntry(name: string, _opts?: { recursive?: boolean }) {
+      if (!this.dirs.delete(name) && !this.files.delete(name)) {
+        throw new DOMException("NotFound", "NotFoundError");
+      }
+    }
+  }
+  const root = new FakeDirHandle();
+  (navigator as any).storage = { getDirectory: async () => root };
+  return () => { delete (navigator as any).storage; };
+}
+
+describe("stagedFileStore — memory backend", () => {
+  let store: StagedFileStore;
+  beforeEach(() => { store = createStagedFileStore({ forceMemory: true }); });
+
+  test("uses the memory backend when forced", () => {
+    expect(store.backend).toBe("memory");
+  });
+
+  test("stores, reports, and reads back files in insertion order", async () => {
+    await store.write("data/subject-1_data.csv", "a,b\n1,2");
+    await store.write("data/raw/sub01.json", "[]");
+
+    expect(store.has("data/subject-1_data.csv")).toBe(true);
+    expect(store.has("missing.csv")).toBe(false);
+    expect(store.paths()).toEqual(["data/subject-1_data.csv", "data/raw/sub01.json"]);
+    await expect(blobText(await store.read("data/subject-1_data.csv"))).resolves.toBe("a,b\n1,2");
+    expect(await collect(store)).toEqual([
+      ["data/subject-1_data.csv", "a,b\n1,2"],
+      ["data/raw/sub01.json", "[]"],
+    ]);
+  });
+
+  test("accepts Blob content as well as strings", async () => {
+    await store.write("data/x_data.csv", new Blob(["c,d\n3,4"]));
+    await expect(blobText(await store.read("data/x_data.csv"))).resolves.toBe("c,d\n3,4");
+  });
+
+  test("clear() empties the store", async () => {
+    await store.write("data/x_data.csv", "x");
+    await store.clear();
+    expect(store.paths()).toEqual([]);
+    expect(store.has("data/x_data.csv")).toBe(false);
+  });
+});
+
+describe("stagedFileStore — OPFS backend (faked)", () => {
+  let uninstall: () => void;
+  beforeEach(() => { uninstall = installFakeOpfs(); });
+  afterEach(() => uninstall());
+
+  test("selects the OPFS backend when navigator.storage.getDirectory exists", () => {
+    expect(opfsAvailable()).toBe(true);
+    expect(createStagedFileStore().backend).toBe("opfs");
+  });
+
+  test("round-trips a nested path through encoded OPFS filenames", async () => {
+    const store = createStagedFileStore();
+    await store.write("data/raw/sub 01.json", '{"ok":true}'); // space exercises path encoding
+    await store.write("data/subject-1_data.csv", "a,b\n1,2");
+
+    expect(store.paths()).toEqual(["data/raw/sub 01.json", "data/subject-1_data.csv"]);
+    await expect(blobText(await store.read("data/raw/sub 01.json"))).resolves.toBe('{"ok":true}');
+    expect(await collect(store)).toEqual([
+      ["data/raw/sub 01.json", '{"ok":true}'],
+      ["data/subject-1_data.csv", "a,b\n1,2"],
+    ]);
+  });
+
+  test("clear() is idempotent even before anything is written", async () => {
+    const store = createStagedFileStore();
+    await expect(store.clear()).resolves.toBeUndefined();
+    await store.write("data/x_data.csv", "x");
+    await store.clear();
+    expect(store.paths()).toEqual([]);
+  });
+});

--- a/packages/frontend/tests/stagedFileStore.test.ts
+++ b/packages/frontend/tests/stagedFileStore.test.ts
@@ -1,6 +1,7 @@
 import {
   createStagedFileStore,
   opfsAvailable,
+  sweepStaleStagingDirs,
   type StagedFileStore,
 } from "../src/staging/stagedFileStore";
 
@@ -25,6 +26,7 @@ async function collect(store: StagedFileStore): Promise<Array<[string, string]>>
 // with createWritable()/getFile(), and recursive removeEntry().
 function installFakeOpfs() {
   class FakeFileHandle {
+    readonly kind = "file" as const;
     constructor(private store: Map<string, Blob>, private key: string) {}
     async createWritable() {
       const parts: Array<string | Blob> = [];
@@ -42,8 +44,13 @@ function installFakeOpfs() {
     }
   }
   class FakeDirHandle {
+    readonly kind = "directory" as const;
     files = new Map<string, Blob>();
     dirs = new Map<string, FakeDirHandle>();
+    async *entries(): AsyncIterableIterator<[string, FakeDirHandle | FakeFileHandle]> {
+      for (const [name, dir] of this.dirs) yield [name, dir];
+      for (const [name] of this.files) yield [name, new FakeFileHandle(this.files, name)];
+    }
     async getDirectoryHandle(name: string, opts?: { create?: boolean }) {
       let d = this.dirs.get(name);
       if (!d) {
@@ -135,5 +142,48 @@ describe("stagedFileStore — OPFS backend (faked)", () => {
     await store.write("data/x_data.csv", "x");
     await store.clear();
     expect(store.paths()).toEqual([]);
+  });
+
+  test("two stores are isolated — one's clear() leaves the other's files intact", async () => {
+    // Per-session subdirs mean concurrent tabs never share (or delete) each other's staged data.
+    const a = createStagedFileStore();
+    const b = createStagedFileStore();
+    await a.write("data/a_data.csv", "a");
+    await b.write("data/b_data.csv", "b");
+
+    await b.clear();
+
+    expect(b.paths()).toEqual([]);
+    await expect(blobText(await a.read("data/a_data.csv"))).resolves.toBe("a");
+  });
+
+  test("write() after clear() recreates the session subdir", async () => {
+    const store = createStagedFileStore();
+    await store.write("data/x_data.csv", "x");
+    await store.clear();
+    await store.write("data/y_data.csv", "y"); // must not throw on the removed handle
+    expect(store.paths()).toEqual(["data/y_data.csv"]);
+    await expect(blobText(await store.read("data/y_data.csv"))).resolves.toBe("y");
+  });
+
+  test("sweepStaleStagingDirs reclaims old/stray entries but keeps fresh sessions", async () => {
+    const root = await (navigator as any).storage.getDirectory();
+    const staging = await root.getDirectoryHandle("psychds-staging", { create: true });
+    const now = Date.now();
+    const oldName = `${(now - 1000 * 60 * 60 * 48).toString(36)}-dead`; // 48h ago
+    const freshName = `${now.toString(36)}-live`;
+    await staging.getDirectoryHandle(oldName, { create: true });
+    await staging.getDirectoryHandle(freshName, { create: true });
+    await staging.getFileHandle("stray-leftover", { create: true }); // pre-subdir-layout file
+
+    await sweepStaleStagingDirs(); // default 24h TTL
+
+    const remaining: string[] = [];
+    for await (const [name] of (staging as any).entries()) remaining.push(name);
+    expect(remaining).toEqual([freshName]);
+  });
+
+  test("sweepStaleStagingDirs is a no-op when nothing has been staged", async () => {
+    await expect(sweepStaleStagingDirs()).resolves.toBeUndefined();
   });
 });

--- a/packages/frontend/tests/validatePsychDS.test.ts
+++ b/packages/frontend/tests/validatePsychDS.test.ts
@@ -4,6 +4,7 @@ import {
   validatePsychDS,
   ValidationUnavailableError,
 } from "../src/validation/validatePsychDS";
+import { createStagedFileStore } from "../src/staging/stagedFileStore";
 import { validatorOutput } from "./helpers";
 
 const mockValidateWeb = validateWeb as jest.Mock;
@@ -52,11 +53,11 @@ describe("validatePsychDS", () => {
 
   test("inserts data files at their dataset-relative paths", async () => {
     mockValidateWeb.mockResolvedValue(validatorOutput([]));
-    // Keys are already dataset-relative paths (built by the upload step), inserted as-is.
-    const dataFiles = new Map([
-      ["data/subject-sub01_data.csv", "a,b\n1,2"],
-      ["data/raw/sub01.json", "[]"],
-    ]);
+    // Paths are already dataset-relative (built by the upload step); the staged store yields them
+    // as Blobs, read one at a time, and the validator tree is built from those.
+    const dataFiles = createStagedFileStore({ forceMemory: true });
+    await dataFiles.write("data/subject-sub01_data.csv", "a,b\n1,2");
+    await dataFiles.write("data/raw/sub01.json", "[]");
     await validatePsychDS("{}", dataFiles);
 
     const [tree] = mockValidateWeb.mock.calls[0];


### PR DESCRIPTION
**Draft** — prototype for the browser memory ceiling discussed in #95. Opening for visibility/approach review while we decide how far to take it.

## Problem

The in-browser pipeline held the whole converted Psych-DS payload in the JS heap at once: `DataUpload` accumulated every converted CSV (and every preserved raw original) into a `Map<string,string>` persisted in React state, then `Review` handed all of it to JSZip *and* to the validator (rebuilt as Blobs). For a large multi-file study (e.g. the ~39×70 MB Tobii case from #95) that's several full copies resident simultaneously → OOM the tab.

(The validator itself already streams — it walks the file tree one file at a time via an async generator. The full hold was entirely on our side.)

## Approach

A staging store keeps each file's bytes on disk via the **Origin Private File System (OPFS)** instead of the heap, and the consumers read it back **one file at a time**:

- `stagedFileStore.ts` — `StagedFileStore` writes each converted/raw file to OPFS (disk-backed) and exposes a lazy `entries()` iterator. Falls back to an in-memory store when OPFS is unavailable (older browsers, non-secure contexts, jsdom). No save-dialog permission needed.
- `DataUpload` writes each file to the store as it's produced (`DataSession.convertedFiles: Map` → `convertedStore: StagedFileStore`), clearing on re-process.
- `validatePsychDS` builds its `WebFileTree` from a lazy `DatasetFileSource`, pulling one Blob at a time.
- `Review` builds the download via `buildDatasetZipBlob` (reads the store one file at a time) and hands the store straight to validation.

Behavior is unchanged — purely the memory refactor.

## Staging lifecycle & cleanup

OPFS is persistent, origin-scoped disk storage, so staged bytes have to be managed across the session's full lifecycle rather than left to the GC. The store covers each exit path:

- **Per-session isolation.** Each `StagedFileStore` writes under its own timestamped subdirectory of `psychds-staging/` (`<base36-timestamp>-<random>/`). Two tabs of the same origin therefore never read or clear each other's staged files, and `clear()` removes only the current session's subdir. The session directory handle is memoized, so reads/writes no longer re-resolve it on every call.
- **Re-process** clears the session's subdir before re-staging.
- **Start Over** clears the session's subdir immediately (`AppShell` clears the store before resetting), so discarding a project doesn't leave participant data on disk.
- **Crash / abrupt tab close** can't run synchronous cleanup, so `sweepStaleStagingDirs()` runs once at app startup (`main.tsx`) and reclaims subdirs left behind by earlier sessions. A 24h TTL (recoverable from the timestamp prefix) means a concurrently-open tab's live session is never swept out from under it.

This also resolves three issues raised in review of the earlier revisions: cross-tab clobbering (a second tab's `clear()` deleting the first's staged data), per-op directory-handle re-resolution, and staged data persisting on disk after the work was done.

## Measurement

Measured in-browser (Chromium) on a synthetic Tobii-scale dataset (generator added: `packages/frontend/scripts/gen-synthetic-dataset.mjs`, seeded for reproducibility), comparing `main` vs this branch through upload → validate → download:

- **Peak heap during processing: flat on this branch; grows substantially on `main`** as the dataset scales — the core win (peak bounded to ~one file's working set).
- **Resting heap lower** (~220 MB → ~120 MB): the converted payload no longer persists in React state.

## Known follow-ups (not in this PR)

- **Raw input still in heap:** `DataUpload` pre-reads every uploaded file into a `fileTexts` map on both branches. Since `File` objects are already disk-backed by the browser, reading each on demand during processing would flatten the input side too — that's why the floor is ~120 MB rather than near-nothing.
- **Output Blob:** JSZip's output Blob isn't the bottleneck at this scale (peak stayed flat); if it becomes one, `datasetZip.ts` is the seam to swap in a streaming zip (`client-zip`).
- Rebases on top of #120 (parse-once); expect a small keep-both conflict in `DataUpload.tsx`.

## Testing

All 236 frontend tests pass; frontend typecheck clean. Tests dogfood the in-memory staging store and cover per-session isolation, the stale-dir startup sweep, and Start Over cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
