### PR TITLE
perf(frontend): read uploaded files on demand to bound input-side memory (#95)

### DIFF
--- a/packages/frontend/src/pages/DataUpload.tsx
+++ b/packages/frontend/src/pages/DataUpload.tsx
@@ -15,7 +15,6 @@ export type FileStatus = {
 
 export type DataSession = {
   files: File[];
-  fileTexts: Map<string, { content: string; type: string }>;
   /**
    * Staged Psych-DS `data/` payload built from the uploaded files (dataset-relative paths such as
    * `data/subject-sub01_data.csv`, `data/raw/sub01.json`). JSON is converted to Psych-DS-named CSV
@@ -32,7 +31,6 @@ export type DataSession = {
 
 export const emptyDataSession: DataSession = {
   files: [],
-  fileTexts: new Map(),
   convertedStore: null,
   joinKeyCandidates: [],
   joinKeyProblemFile: '',
@@ -58,6 +56,16 @@ const readFileAsText = (file: File): Promise<string> =>
     reader.onerror = reject;
     reader.readAsText(file);
   });
+
+/**
+ * Normalised data-file type for routing. `.jsonl` is treated as `json` (parseJsonData accepts
+ * both a single array and one JSON value per line, so JSONL flows through the same path), and
+ * everything else keeps its lowercased extension.
+ */
+const dataFileType = (name: string): string => {
+  const ext = name.split('.').pop()?.toLowerCase() || '';
+  return ext === 'jsonl' ? 'json' : ext;
+};
 
 /** Filename without its extension (e.g. "sub01.json" → "sub01"). */
 const fileStem = (name: string): string => name.replace(/\.[^./]+$/, '');
@@ -105,7 +113,6 @@ const DataUpload: React.FC<DataUploadProps> = ({
   const [files, setFiles] = useState<File[]>(session.files);
   const [sourceName, setSourceName] = useState('');
   const [pickError, setPickError] = useState('');
-  const [fileTexts, setFileTexts] = useState(session.fileTexts);
   const [convertedStore, setConvertedStore] = useState<StagedFileStore | null>(session.convertedStore);
   const [fileStatuses, setFileStatuses] = useState<FileStatus[]>(session.fileStatuses);
   const [joinKeyCandidates, setJoinKeyCandidates] = useState<JoinKeyCandidate[]>(session.joinKeyCandidates);
@@ -121,9 +128,9 @@ const DataUpload: React.FC<DataUploadProps> = ({
   onSessionChangeRef.current = onSessionChange;
   useEffect(() => {
     onSessionChangeRef.current({
-      files, fileTexts, convertedStore, joinKeyCandidates, joinKeyProblemFile, selectedKeys: committedKeys, fileStatuses,
+      files, convertedStore, joinKeyCandidates, joinKeyProblemFile, selectedKeys: committedKeys, fileStatuses,
     });
-  }, [files, fileTexts, convertedStore, joinKeyCandidates, joinKeyProblemFile, committedKeys, fileStatuses]);
+  }, [files, convertedStore, joinKeyCandidates, joinKeyProblemFile, committedKeys, fileStatuses]);
 
   useEffect(() => {
     if (inputRef.current) (inputRef.current as any).webkitdirectory = true; // not in TS lib
@@ -173,24 +180,25 @@ const DataUpload: React.FC<DataUploadProps> = ({
   const handleProcess = async () => {
     setPhase('preflight');
 
-    const textMap = new Map<string, { content: string; type: string }>();
-    for (const file of files) {
-      const rawExt = file.name.split('.').pop()?.toLowerCase() || '';
-      // Treat JSON-Lines as JSON: parseJsonData() accepts both a single array and one
-      // JSON value per line, so .jsonl flows through the same path as .json downstream.
-      const type = rawExt === 'jsonl' ? 'json' : rawExt;
-      const content = await readFileAsText(file);
-      textMap.set(file.webkitRelativePath || file.name, { content, type });
-    }
-    setFileTexts(textMap);
-
     // Pre-flight: check join key uniqueness. Only JSON files are checked because
     // analyzeJoinKeys expects a parsed array of objects; CSV parsing would require
     // an extra parse step and CSV experiments are typically single-participant files
     // where trial_index is already unique.
-    for (const [name, { content, type }] of textMap) {
-      if (type !== 'json') continue;
+    //
+    // Each file is read on demand and dropped when the iteration ends, so the whole
+    // upload is never resident in the heap at once (File objects are already disk-backed
+    // by the browser). The trade-off is that JSON files are read again in runGenerate —
+    // intentional: this step bounds peak memory, not total I/O.
+    for (const file of files) {
+      const name = file.webkitRelativePath || file.name;
+      if (dataFileType(file.name) !== 'json') continue;
       if (name === 'dataset_description.json' || name.endsWith('/dataset_description.json')) continue;
+      let content: string;
+      try {
+        content = await readFileAsText(file);
+      } catch {
+        continue;
+      }
       try {
         // Tag a per-line source_record_id for JSON-Lines (a no-op for a single array).
         const parsed = parseJsonData(content, { tagSourceRecordId: true });
@@ -214,13 +222,13 @@ const DataUpload: React.FC<DataUploadProps> = ({
       }
     }
 
-    await runGenerate(textMap, ['trial_index'], true);
+    await runGenerate(['trial_index'], true);
   };
 
   const handleJoinKeyApply = async () => {
     const keys = proceedAnyway ? ['trial_index'] : selectedKeys;
     setCommittedKeys(keys);
-    await runGenerate(fileTexts, keys, proceedAnyway);
+    await runGenerate(keys, proceedAnyway);
   };
 
   const toggleKey = (col: string) => {
@@ -230,7 +238,6 @@ const DataUpload: React.FC<DataUploadProps> = ({
   };
 
   const runGenerate = async (
-    textMap: Map<string, { content: string; type: string }>,
     joinKeys: string[],
     suppressWarning: boolean
   ) => {
@@ -253,9 +260,6 @@ const DataUpload: React.FC<DataUploadProps> = ({
 
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
-      const entry = textMap.get(file.webkitRelativePath || file.name);
-      if (!entry) continue;
-      const { content, type } = entry;
 
       update(i, { status: 'loading' });
 
@@ -265,8 +269,19 @@ const DataUpload: React.FC<DataUploadProps> = ({
         continue;
       }
 
+      const type = dataFileType(file.name);
       if (type !== 'json' && type !== 'csv') {
         update(i, { status: 'skipped', detail: 'unsupported file type' });
+        continue;
+      }
+
+      // Read this file's text on demand; it goes out of scope at the end of the iteration,
+      // so peak heap is bounded to one file's working set rather than the whole upload.
+      let content: string;
+      try {
+        content = await readFileAsText(file);
+      } catch (e) {
+        update(i, { status: 'error', detail: String(e) });
         continue;
       }
 
@@ -429,7 +444,7 @@ const DataUpload: React.FC<DataUploadProps> = ({
           <button className={styles.continueBtn} onClick={onComplete}>
             Continue →
           </button>
-          {joinKeyCandidates.length > 0 && fileTexts.size > 0 && (
+          {joinKeyCandidates.length > 0 && files.length > 0 && (
             <button className={styles.reConfigureBtn} onClick={() => enterReConfigureJoinKeys('hasData')}>
               Re-configure join keys
             </button>

--- a/packages/frontend/src/pages/DataUpload.tsx
+++ b/packages/frontend/src/pages/DataUpload.tsx
@@ -197,6 +197,9 @@ const DataUpload: React.FC<DataUploadProps> = ({
       try {
         content = await readFileAsText(file);
       } catch {
+        // A read failure here only skips this file's join-key prompt; runGenerate reads it
+        // again and surfaces the failure as a per-file 'error' status, so we never silently
+        // emit duplicate rows. Hence skip quietly rather than mirroring that error handling.
         continue;
       }
       try {

--- a/packages/frontend/tests/AppShell.test.tsx
+++ b/packages/frontend/tests/AppShell.test.tsx
@@ -50,13 +50,13 @@ jest.mock("../src/pages/DataUpload", () => ({
       <span>DataUpload page</span>
       <button onClick={onComplete}>Complete DataUpload</button>
       <button
-        onClick={() => onSessionChange({ files: [], fileTexts: new Map(), convertedStore: mockStagedStore })}
+        onClick={() => onSessionChange({ files: [], convertedStore: mockStagedStore })}
       >
         Stage data
       </button>
     </div>
   ),
-  emptyDataSession: { fileTexts: [], files: [] },
+  emptyDataSession: { files: [] },
 }));
 
 jest.mock("../src/pages/Variables", () => ({

--- a/packages/frontend/tests/DataUpload.test.tsx
+++ b/packages/frontend/tests/DataUpload.test.tsx
@@ -141,11 +141,11 @@ describe("DataUpload", () => {
       expect(screen.getByText("parse failed")).toBeInTheDocument();
     });
 
-    test("shows Re-configure join keys when candidates and fileTexts exist", () => {
+    test("shows Re-configure join keys when candidates and files exist", () => {
       const session: DataSession = {
         ...emptyDataSession,
         joinKeyCandidates: [{ column: "subject", makesUnique: true }],
-        fileTexts: new Map([["data.json", { content: "[]", type: "json" }]]),
+        files: [makeFile("data.json", "[]")],
       };
       render(<DataUpload {...props({ dataProcessed: true, session })} />);
       expect(screen.getByRole("button", { name: "Re-configure join keys" })).toBeInTheDocument();


### PR DESCRIPTION
**Draft** — input-side follow-up to #121 (the OPFS output-staging prototype) for the browser memory ceiling in #95. **Stacked on `feat/opfs-staging-prototype`** — review/merge that first; the diff here is just the input-side change.

## Problem

`DataUpload` pre-read *every* uploaded file into a `fileTexts: Map<path, {content, type}>` held in React session state, so a large multi-file study sat fully in the JS heap before any processing began. This is the input-side counterpart to the output staging in #121, and it's why the staged-pipeline floor stayed ~120 MB rather than near a single file's working set.

## Approach

Drop the `fileTexts` map entirely and read each `File` lazily:

- The join-key **preflight** reads only JSON files, on demand, and drops each after checking.
- `runGenerate` reads each supported file as it processes it, letting the bytes go out of scope at the end of the iteration — peak input heap is bounded to roughly one file.
- Unsupported files are no longer read at all.
- Re-configure-join-keys re-reads from the retained `File[]` (already disk-backed by the browser) instead of the dropped map, so behavior is unchanged.

Trade-off (documented in-code): JSON files are read twice — once in preflight, once in `generate()`. That's deliberate — this bounds peak memory, not total I/O, and `File` re-reads come straight off disk.

## Measurement (Chromium, synthetic Tobii-scale dataset)

Compared against `feat/opfs-staging-prototype` through upload → validate → download:

- **Resting/baseline heap ~20 MB** (down from ~120 MB on the parent branch) — the input is no longer buffered.
- **~100 MB lower across the run** generally.
- Most phases stayed **under ~200 MB** (occasionally just over).
- The only spike **past ~300 MB is during download** — i.e. the JSZip output Blob, the remaining hotspot already flagged in #121 (seam: `datasetZip.ts`, candidate swap: `client-zip`). Not addressed here.

## Testing

All 236 frontend tests pass; `tsc --noEmit` clean. Updated the two tests that referenced `fileTexts` (the re-configure gating test now keys off `files`; the AppShell mock drops the field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
