### PR TITLE
fix(cli): create data/ dir when updating an existing project that lacks one (#118)

### DIFF
--- a/.changeset/existing-project-data-dir.md
+++ b/.changeset/existing-project-data-dir.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata-cli": patch
+---
+
+Create the output `data/` directory when updating an existing project that doesn't have one. When `--psych-ds-dir` points at a minimal or hand-rolled Psych-DS skeleton with no `data/` subdirectory, writing the first converted CSV failed with `ENOENT`, which surfaced opaquely as `x Data files was unsuccessful with 0 files read` and `MISSING_DATAFILE`/`MISSING_DATA_DIRECTORY`. `processDirectory` now ensures the target `data/` directory exists before writing (recursive, so it's a no-op when present). A brand-new project already got this from `createDirectoryWithStructure`; JSON inputs only dodged it incidentally by creating `data/raw/` first, so CSV-only existing projects were the ones that broke. Fixes #118.

--- a/packages/cli/src/data.ts
+++ b/packages/cli/src/data.ts
@@ -546,6 +546,16 @@ export const processDirectory = async (metadata: JsPsychMetadata, directoryPath:
       return 0;
     });
 
+    // Ensure the output data/ directory exists before writing into it. A brand-new project gets
+    // this from createDirectoryWithStructure, but an existing project pointed at via --psych-ds-dir
+    // may be a minimal/hand-rolled skeleton with no data/ dir. CSV inputs write straight into
+    // targetDirectoryPath, so without this the first writeFile fails with ENOENT and the run
+    // misreports it as "0 files read" (#118). (JSON inputs only dodged this incidentally, by
+    // creating data/raw/ first.) Recursive, so it's a no-op when the directory already exists.
+    if (targetDirectoryPath) {
+      await fs.promises.mkdir(targetDirectoryPath, { recursive: true });
+    }
+
     for (const { dirPath, name } of files) {
       total += 1;
       if (!await processFile(metadata, dirPath, name, verbose, targetDirectoryPath, options, usedArrayFilenames, usedRawFilenames)) failed += 1;

--- a/packages/cli/tests/data.test.ts
+++ b/packages/cli/tests/data.test.ts
@@ -324,6 +324,26 @@ describe("preAnalyzeDirectory", () => {
   });
 });
 
+describe("processDirectory output-directory creation (#118)", () => {
+  test("creates a missing data/ directory for a CSV input instead of failing with ENOENT", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    // Mirrors an existing Psych-DS project with no data/ dir: the output path doesn't exist yet.
+    const dataDir = path.join(tmpDir, "project", "data");
+    fs.mkdirSync(srcDir);
+    // A CSV input (no data/raw/ is created for CSV, so nothing else would make data/ first).
+    // "subject-1" yields the compliant "subject-1_data.csv" without needing a rename plan.
+    fs.writeFileSync(path.join(srcDir, "subject-1.csv"), "trial_type,rt\njsPsych-html-keyboard-response,450");
+
+    expect(fs.existsSync(dataDir)).toBe(false);
+
+    const { total, failed } = await processDirectory(new JsPsychMetadata(), srcDir, false, dataDir);
+
+    expect(total).toBe(1);
+    expect(failed).toBe(0);
+    expect(fs.existsSync(path.join(dataDir, "subject-1_data.csv"))).toBe(true);
+  });
+});
+
 describe("processDirectory JSON → CSV conversion", () => {
   test("writes a converted CSV to data/ and preserves the original JSON under data/raw/", async () => {
     const srcDir = path.join(tmpDir, "src");


### PR DESCRIPTION
Fixes #118.

## Problem

When `--psych-ds-dir` points at an *existing* project whose folder has no `data/` subdirectory (a minimal or hand-rolled Psych-DS skeleton), the CLI writes converted data files into `<project>/data` but never creates that directory. The first `writeFile` throws `ENOENT`, which surfaces opaquely as:

```
Error reading file task-resp_data.csv: ENOENT ... <project>\data\task-resp_data.csv
x Data files was unsuccessful with 0 files read.
✘ Psych-DS validation failed: MISSING_DATAFILE / MISSING_DATA_DIRECTORY
```

It looks like a data-parsing failure rather than "I couldn't create the output directory."

## Root cause

Only the **new-project** path calls `createDirectoryWithStructure` (which builds `data/` + `data/raw/`); the existing-project path (`new_project = false`) skips it. JSON inputs accidentally dodged the bug because `processFile` creates `data/raw/` (which creates `data/`) before writing — but **CSV-only** existing projects had nothing create `data/` first, so they broke.

## Fix

`processDirectory` now ensures the target `data/` directory exists before writing into it (`fs.mkdir(targetDirectoryPath, { recursive: true })`, a no-op when it already exists). One spot, covers both CSV and JSON inputs and all callers.

## Testing

- New test in `data.test.ts`: a CSV input with a non-existent target `data/` dir now writes successfully (`total: 1, failed: 0`) and creates the directory, instead of failing.
- Full `data.test.ts` green (45/45). The two unrelated suite failures locally (`interactive-rename.e2e` missing `node-pty`; `validatefunctions` Windows backslash path) are pre-existing env-only failures, green on CI.
- Changeset added (`@jspsych/metadata-cli` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
