### PR TITLE
fix(metadata): exclude unnamed columns from join-key candidates (#117)

### DIFF
--- a/.changeset/join-key-exclude-unnamed.md
+++ b/.changeset/join-key-exclude-unnamed.md
@@ -1,0 +1,7 @@
+---
+"@jspsych/metadata": patch
+"@jspsych/metadata-cli": patch
+"frontend": patch
+---
+
+Don't propose unnamed/whitespace-only-header columns as join keys. R's `write.csv` (default `row.names = TRUE`) prepends an unnamed row-index column (empty-string header) that is unique per row, so `analyzeJoinKeys` would offer it as a join-key candidate — and the headless resolver (`resolveJoinKeysNonInteractive`), picking the lexicographically-first sufficient column, could choose it (logging a confusing `added ""`). But `stripUnnamedColumns` (#114) drops that column from the written output, so the chosen key would then vanish from the extracted sidecar. `analyzeJoinKeys` now excludes empty/whitespace-only-header columns from candidate selection (the same predicate `stripUnnamedColumns` uses), so the resolver, the interactive prompt, and the frontend join-key chooser never propose a column that can't survive to the output. Fixes #117.

--- a/packages/cli/tests/data.test.ts
+++ b/packages/cli/tests/data.test.ts
@@ -602,6 +602,24 @@ describe("resolveJoinKeysNonInteractive", () => {
     expect(result.message).toContain("subject_id");
   });
 
+  test("never picks an unnamed row-index column; chooses the real key instead (#117)", () => {
+    // R's write.csv prepends a unique unnamed ("") row-index column. It sorts first, so the greedy
+    // resolver used to pick it (logging the confusing `added ""`) — but #114 drops it from the
+    // written sidecar, so the key would vanish. analyzeJoinKeys now excludes unnamed columns, so
+    // the resolver lands on subject_id instead.
+    const rRows = [
+      { "": "1", trial_index: 0, subject_id: "s1", rt: 1 },
+      { "": "2", trial_index: 1, subject_id: "s1", rt: 2 },
+      { "": "3", trial_index: 0, subject_id: "s2", rt: 1 },
+      { "": "4", trial_index: 1, subject_id: "s2", rt: 2 },
+    ];
+    const analysis = analyzeJoinKeys(rRows, ["trial_index"]);
+    const result = resolveJoinKeysNonInteractive(analysis, ["trial_index"], "task-resp_data.csv");
+    expect(result.keys).toEqual(["trial_index", "subject_id"]);
+    expect(result.keys).not.toContain("");
+    expect(result.message).not.toContain('added ""');
+  });
+
   test("uses the greedy combination when no single column suffices", () => {
     // Neither session nor block alone makes trial_index unique, but together they do.
     const rows = [

--- a/packages/metadata/src/utils.ts
+++ b/packages/metadata/src/utils.ts
@@ -248,9 +248,10 @@ export function analyzeJoinKeys(
   // Exclude unnamed/whitespace-only-header columns (e.g. R write.csv's row-index column):
   // stripUnnamedColumns (#114) drops them from the written output, so proposing one as a join
   // key — interactively or in the headless resolver — would pick a column that can't survive to
-  // the sidecar, and emit a confusing `added ""` message (#117). Same predicate as the drop.
+  // the sidecar, and emit a confusing `added ""` message (#117). Reuse isUnnamedHeader so this
+  // can never diverge from the drop.
   const candidateColumns = [...allColumns].filter(
-    col => col.trim() !== "" && !keySet.has(col) && !SYSTEM_COLUMNS.has(col)
+    col => !isUnnamedHeader(col) && !keySet.has(col) && !SYSTEM_COLUMNS.has(col)
   );
 
   // 3. Categorise: does (keys + col) achieve uniqueness?

--- a/packages/metadata/src/utils.ts
+++ b/packages/metadata/src/utils.ts
@@ -245,8 +245,12 @@ export function analyzeJoinKeys(
   const allColumns = new Set<string>();
   for (const row of parsedData) for (const col of Object.keys(row)) allColumns.add(col);
 
+  // Exclude unnamed/whitespace-only-header columns (e.g. R write.csv's row-index column):
+  // stripUnnamedColumns (#114) drops them from the written output, so proposing one as a join
+  // key — interactively or in the headless resolver — would pick a column that can't survive to
+  // the sidecar, and emit a confusing `added ""` message (#117). Same predicate as the drop.
   const candidateColumns = [...allColumns].filter(
-    col => !keySet.has(col) && !SYSTEM_COLUMNS.has(col)
+    col => col.trim() !== "" && !keySet.has(col) && !SYSTEM_COLUMNS.has(col)
   );
 
   // 3. Categorise: does (keys + col) achieve uniqueness?

--- a/packages/metadata/tests/metadata-nested-columns.test.ts
+++ b/packages/metadata/tests/metadata-nested-columns.test.ts
@@ -411,6 +411,26 @@ describe("analyzeJoinKeys", () => {
     expect(cols).not.toContain("trial_index");
   });
 
+  test("excludes unnamed/whitespace-only-header columns from candidates (#117)", () => {
+    // R's write.csv prepends an unnamed row-index column (empty-string header). It's unique, so a
+    // greedy resolver would happily pick it — but stripUnnamedColumns (#114) drops it from the
+    // written output, so it must never be proposed as a join key (interactively or headless).
+    const withRowIndex = [
+      { "": "1", "  ": "a", trial_index: 0, subject_id: "s1" },
+      { "": "2", "  ": "b", trial_index: 1, subject_id: "s1" },
+      { "": "3", "  ": "c", trial_index: 0, subject_id: "s2" },
+      { "": "4", "  ": "d", trial_index: 1, subject_id: "s2" },
+    ];
+    const result = analyzeJoinKeys(withRowIndex, ["trial_index"]);
+    const cols = result.candidates.map(c => c.column);
+    expect(cols).not.toContain("");      // empty header
+    expect(cols).not.toContain("  ");    // whitespace-only header
+    expect(cols).toContain("subject_id"); // the legitimate key is still offered
+    // and an unnamed column is never smuggled into a greedy combination either
+    expect(result.suggestedAdditionalKeys ?? []).not.toContain("");
+    expect(result.suggestedAdditionalKeys ?? []).not.toContain("  ");
+  });
+
   test("marks subject_id as makesUnique: true (it alone resolves all duplicates)", () => {
     const result = analyzeJoinKeys(rows, ["trial_index"]);
     const subjectCandidate = result.candidates.find(c => c.column === "subject_id");


### PR DESCRIPTION
Fixes #117.

## Problem

R's `write.csv` (default `row.names = TRUE`) prepends an unnamed row-index column, which surfaces as an empty-string (`""`) header. That column is unique per row, so `analyzeJoinKeys` offered it as a join-key candidate. In a headless run, `resolveJoinKeysNonInteractive` picks the lexicographically-first sufficient column — and `""` sorts first — so it could choose it:

```
ℹ  [trial_index] not unique in "task-resp_data.csv"; non-interactive run — added "" so [trial_index, ] uniquely identifies all rows.
```

But `stripUnnamedColumns` (#114) drops that column from the written output, so for a dataset with *both* an unnamed leading column *and* array/object columns, the chosen join key would vanish from the extracted sidecar. (Benign today only because such files have no sidecars; the `added ""` log line is confusing regardless.)

## Fix

`analyzeJoinKeys` now excludes empty/whitespace-only-header columns from candidate selection, using the **same predicate** `stripUnnamedColumns` uses (`col.trim() !== ""`). Fixing it at the source means the headless resolver, the interactive prompt, and the frontend join-key chooser all stop proposing a column that can't survive to the output — they land on the real key (e.g. `subject_id`) instead.

## Testing

- `analyzeJoinKeys` unit test: empty- and whitespace-only-header columns are excluded from candidates and never enter a greedy combination, while the legitimate key is still offered.
- `resolveJoinKeysNonInteractive` integration test: R-style data with a unique `""` row-index column now resolves to `[trial_index, subject_id]` (not `[trial_index, ""]`), with no `added ""` message.
- Full metadata suite green (248/248). CLI `data.test.ts` green (45/45); the two unrelated local suite failures (`interactive-rename.e2e` missing `node-pty`, `validatefunctions` Windows backslash path) are pre-existing env-only failures, green on CI.
- Changeset added (metadata + cli + frontend patch, mirroring #114's scope since the shared helper changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
