### PR TITLE
docs(frontend): document in-browser validation + data-conversion flow

### DIFF
--- a/.changeset/document-frontend-validation-flow.md
+++ b/.changeset/document-frontend-validation-flow.md
@@ -1,0 +1,5 @@
+---
+"frontend": patch
+---
+
+Document the frontend's in-browser Psych-DS validation flow and the JSON→CSV data-conversion pipeline. Adds "Data conversion pipeline" and "In-browser validation" sections to `docs/dev/frontend-architecture.md` (covering `validatePsychDS`, the `WebFileTree` build, the `schema: 'latest'` choice, `ValidationUnavailableError`, and the zip-resolved README/CHANGES warnings), and notes in the user README explaining that JSON data is converted to Psych-DS CSV (originals kept under `data/raw/`) and what the in-browser validator reports. Documentation only — no behavior change.

--- a/docs/dev/frontend-architecture.md
+++ b/docs/dev/frontend-architecture.md
@@ -35,10 +35,10 @@ packages/frontend/
 │   ├── hooks/
 │   │   └── useTheme.ts     — dark/light theme: reads localStorage, falls back to OS preference
 │   │
-│   └── validation/         — in-browser Psych-DS validation (added by feat/frontend-validator)
-│       ├── validatePsychDS.ts
-│       ├── psychds-validator-web.d.ts
-│       └── node-stub.ts
+│   └── validation/         — in-browser Psych-DS validation (see "In-browser validation" below)
+│       ├── validatePsychDS.ts          — wraps psychds-validator's web build
+│       ├── psychds-validator-web.d.ts  — local types for the web bundle
+│       └── node-stub.ts                — Node-only shim so the bundle resolves under Jest
 ```
 
 > **Note:** the original modal-chain files (`pages/Upload.tsx`, `pages/Options.tsx`, `pages/ViewOptions.tsx`, `components/ListItems.tsx`, `components/Preview.tsx`, `components/popups/`, `components/upload/`, `useExternalScripts.ts`, and `App.css`) have been removed; the redesigned wizard described here is the only active architecture.
@@ -121,6 +121,39 @@ A recursive collapsible renderer for arbitrary JSON. Keys, strings, numbers, boo
 
 ---
 
+## Data conversion pipeline (DataUpload)
+
+The validator and the downloadable zip both expect Psych-DS-compliant CSV data files, so `DataUpload.tsx` converts uploaded data **before** anything reaches Review. For each file it calls `jsPsychMetadata.generate()` to accumulate variable metadata, then builds the converted payload using library exports re-used from `@jspsych/metadata` (`buildPsychDSDataFiles`, `parseCSV`, `parseJsonData`, `analyzeJoinKeys`, `deriveFallbackBase`, `isValidPsychDSDataFilename`, `PSYCHDS_IGNORE_FILENAME`, `PSYCHDS_IGNORE_CONTENT`):
+
+- **JSON arrays** are serialized to Psych-DS-named CSV (e.g. `data/subject-sub01_data.csv`); the original JSON is preserved under `data/raw/<name>`.
+- **CSV** input is written verbatim (an already-compliant filename is kept; otherwise a `subject-<stem>` base is derived). Rows are still parsed so R-style **unnamed row-index columns** can be dropped.
+- **Non-array JSON** is skipped.
+- When raw originals are kept, a top-level **`.psychds-ignore`** file (`PSYCHDS_IGNORE_FILENAME` / `PSYCHDS_IGNORE_CONTENT`) is added so the validator skips `data/raw/`.
+- If a file has **nested arrays** and `trial_index` doesn't uniquely identify rows, a join-key chooser collects extra columns (via `analyzeJoinKeys`) before conversion.
+
+The result is a `convertedFiles` map (dataset-relative path → contents) carried in the `DataSession` and handed to `Review` as `dataFiles`. It drives both validation and the zip, so the two always agree.
+
+---
+
+## In-browser validation
+
+`Review.tsx` validates **post-generation**, on demand, behind a **"Validate dataset"** button — the implementation behind issue #3. The validator chunk is **lazy-loaded** (`await import('../validation/validatePsychDS')`, ~260 KB) so it stays out of the initial bundle.
+
+`validatePsychDS(metadataJson, dataFiles)` (in `src/validation/validatePsychDS.ts`):
+
+1. Ensures `jsonld` is on `window` (`ensureJsonldGlobal`) — the validator's browser path expects it as a global.
+2. Builds a `WebFileTree` from `dataset_description.json` plus the converted `data/` payload (`buildFileTree` / `insertFile`).
+3. Calls `validateWeb(tree, { schema: 'latest' })` from `psychds-validator/web`. `'latest'` (not a pinned version) keeps results consistent with the CLI and deployed web validator and avoids requesting a schema version the server may not have.
+4. Splits the returned issues into `errors` / `warnings` by `severity`, deduping each issue's per-file `evidence` (e.g. the offending column names), and returns `{ valid, errors, warnings }`.
+
+**Network is required** — the validator fetches the Psych-DS schema and schema.org context at runtime. If it can't run, `validatePsychDS` throws `ValidationUnavailableError` with a connectivity-first message (underlying error appended), which Review surfaces as an `unavailable` banner rather than a false "invalid" result.
+
+**Zip-resolved warnings:** the in-browser validator only sees the metadata + data files, so it reports `MISSING_README_DOC` / `MISSING_CHANGES_DOC`. The downloaded zip ships `README.md` and `CHANGES.md`, so Review (`ZIP_RESOLVED_WARNINGS`) shows a reassurance note explaining these clear once the downloaded dataset is validated. A `<details>` block also documents the CLI equivalent (`npx @jspsych/cli validate`).
+
+> The core `@jspsych/metadata` library does **not** validate — validation is a consuming concern owned by the frontend (here) and the CLI (`packages/cli/src/validatefunctions.ts`). Unit tests for these helpers are tracked in issue #94.
+
+---
+
 ## Design system
 
 ### CSS Modules
@@ -176,6 +209,8 @@ The wizard uses a single `JsPsychMetadata` instance created in `App.tsx` and pas
 | `setAuthor(fields)` | Authors | Add or update an author entry (single `AuthorFields` object; keyed by `name`) |
 | `deleteAuthor(name)` | Authors | Remove an author |
 | `getMetadata()` | Review | Serialize the full metadata object to JSON |
+
+Beyond the `JsPsychMetadata` instance, `DataUpload` also imports standalone helpers from `@jspsych/metadata` to build the Psych-DS `data/` payload — `buildPsychDSDataFiles`, `parseCSV`, `parseJsonData`, `analyzeJoinKeys`, `deriveFallbackBase`, `isValidPsychDSDataFilename`, and the `PSYCHDS_IGNORE_*` constants (see [Data conversion pipeline](#data-conversion-pipeline-dataupload)). In-browser validation uses `psychds-validator` directly, not the library (see [In-browser validation](#in-browser-validation)).
 
 ---
 

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -56,6 +56,8 @@ Upload your jsPsych data files (`.csv` or `.json`):
 - Each file is shown with a status indicator once processed.
 - If your data files contain nested arrays, the wizard detects whether `trial_index` uniquely identifies each row. If not, a join-key chooser lets you select additional columns before proceeding — these are used to name the separate CSV files the validator expects.
 
+> **What the wizard does with your files:** JSON data is converted to Psych-DS-named CSV (e.g. `data/subject-sub01_data.csv`) so the validator and the downloaded zip both see compliant tables; your original JSON is preserved under `data/raw/`. CSV uploads are kept as-is. This conversion is what ends up in the downloaded zip.
+
 > **For existing projects:** the Data step is pre-marked complete since your variables are already loaded from the uploaded `dataset_description.json`. You can still upload new data files to regenerate the variable list.
 
 ---
@@ -96,7 +98,8 @@ Inspect the generated `dataset_description.json` and download your project:
       └── <your data files>
   ```
 - If no data files were uploaded, a **Save `dataset_description.json`** button is shown instead.
-- **Validate dataset** runs the Psych-DS validator in-browser and shows any errors or warnings inline. An internet connection is required (the validator fetches the schema from GitHub).
+- **Validate dataset** runs the Psych-DS validator entirely in your browser and lists any errors and warnings inline, each with the underlying rule key and the specific files/columns at fault. An internet connection is required — the validator fetches the Psych-DS schema and schema.org context at runtime.
+  - Because in-browser validation only sees your metadata and data files, it may report missing `README` / `CHANGES` warnings. These are expected: the downloaded zip already includes `README.md` and `CHANGES.md`, so they clear when you validate the downloaded dataset (e.g. with `npx @jspsych/cli validate`).
 
 The **{} Preview** pill button (visible on all steps except Review) opens a live JSON snapshot in a slide-in drawer so you can check the output at any point without leaving the current step.
 


### PR DESCRIPTION
## What & why

Issue #3's in-browser Psych-DS validation (merged to `main`) and the `DataUpload` JSON→CSV conversion pipeline that feeds it were under-documented. This PR fills that gap. **Documentation only — no behavior change.**

This is *new, separate* drift discovered while verifying #3/#23; it does not affect the standing conclusion that both issues are already complete against their original acceptance criteria.

## Changes

**`docs/dev/frontend-architecture.md`**
- Describe the `validation/` files instead of the bare "added by feat/frontend-validator" note.
- New **Data conversion pipeline (DataUpload)** section: JSON→CSV conversion, `data/raw/` preservation, `.psychds-ignore`, unnamed-column dropping, join-key handling, reused `@jspsych/metadata` exports.
- New **In-browser validation** section: the `validatePsychDS` flow (`jsonld` global → `WebFileTree` → `validateWeb({ schema: 'latest' })` → error/warning split), lazy-loading, network requirement / `ValidationUnavailableError`, and the zip-resolved `MISSING_README/CHANGES` warnings. Notes the core library doesn't validate (tests tracked in #94).
- API table: note pointing to the conversion helpers + validator with intra-doc anchors.

**`packages/frontend/README.md`**
- Step 2 (Data): explain JSON→CSV conversion and `data/raw/` preservation so users understand the zip contents.
- Step 5 (Review): expand "Validate dataset" — what the report shows and the expected README/CHANGES warnings.

## Verification
Docs cross-checked against `src/validation/validatePsychDS.ts`, `src/pages/Review.tsx`, and `src/pages/DataUpload.tsx` on `main`. Intra-doc anchor targets verified present. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)