### PR TITLE
docs: reorganize user guides into overview + CLI/frontend pages

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,0 +1,254 @@
+# CLI Guide: Organizing jsPsych Data with the Metadata CLI
+
+This guide walks you through using the jsPsych Metadata CLI to turn your raw experiment data into a [Psych-DS](https://psych-ds.github.io/) compliant dataset. By the end, you'll have a structured project folder with a `dataset_description.json` file that describes your experiment and its variables.
+
+If you're not sure whether the CLI or the browser wizard is right for you, start with [Getting Started](getting-started.md). For a complete list of flags, exit codes, and filename rules, see the [CLI Reference](cli-reference.md).
+
+## Before you start
+
+You'll need:
+
+- **Node.js** installed on your computer (version 18 or later). You can check by running `node --version` in your terminal. If it's not installed, download it from [nodejs.org](https://nodejs.org).
+- **Your jsPsych data files** — CSV, JSON, or JSON-Lines files produced by your experiment. These can be in one folder or organized into subfolders one level deep. See [Accepted data formats](#accepted-data-formats) below.
+
+## Running the tool
+
+Open a terminal and run:
+
+```
+npx @jspsych/metadata-cli
+```
+
+The first time you run this, `npx` will download the tool automatically. After that it launches immediately.
+
+---
+
+## Accepted data formats
+
+The CLI reads jsPsych data in any of these shapes:
+
+- **CSV** — one row per trial. Copied to the project as-is (under a Psych-DS compliant name). Unnamed row-index columns (the blank first column R and some exporters add) are dropped.
+- **JSON array** — the standard jsPsych export: `[ {…}, {…} ]`. Converted to CSV for the project.
+- **`{ "trials": [...] }` wrapper** — some platforms (e.g. OSF) wrap the trial array in an object with a single `trials` key. The CLI unwraps it automatically.
+- **JSON-Lines (`.jsonl`)** — one JSON value per line, as JATOS and several labs export it (often one participant's trial array per line). The CLI flattens every line into a single observation stream.
+
+JSON and JSON-Lines files are converted to CSV in the output (`data/` folder) so the Psych-DS validator can read them; your originals are preserved untouched under `data/raw/`. Files of any other type are ignored.
+
+---
+
+## Interactive walkthrough
+
+The following steps use two example data files named `participant_01.csv` and `participant_02.csv`.
+
+### Step 1: Create a new project or update an existing one
+
+```
+? What would you like to do?
+❯ Create a new project
+  Update an existing project
+```
+
+Select **Create a new project** if this is the first time you're generating metadata for this dataset. Use **Update an existing project** if you've run the tool before and want to regenerate the metadata (for example, after collecting more data).
+
+---
+
+### Step 2: Choose where to save the project
+
+```
+? Path to the folder where the new project will be created:
+```
+
+Enter the path to an existing folder — the tool will create a new subfolder inside it for your project. **The folder you enter here must already exist.**
+
+- **Windows:** `C:\Users\yourname\Documents\experiments`
+- **Mac / Linux:** `/Users/yourname/Documents/experiments` or `~/experiments`
+
+On Windows, you can copy the path directly from File Explorer's address bar. On Mac, you can drag a folder into the terminal window to paste its path. The `~` character is a shortcut for your home folder on Mac and Linux.
+
+---
+
+### Step 3: Name your project
+
+```
+? Enter the project name (used as the folder name and in the metadata): flanker-study
+```
+
+The name becomes the subfolder created inside the folder from Step 2, and is recorded in the metadata. Use something descriptive without spaces (hyphens are fine).
+
+---
+
+### Step 4: Point to your data
+
+```
+? Path to your raw data folder (files will be copied, not moved):
+```
+
+Enter the path to the folder containing your jsPsych data files. Use the same path format as Step 2 — the full path to an existing folder on your computer. Your original files are never modified; the tool copies them into the new project.
+
+---
+
+### Step 5: File naming (if your files need renaming)
+
+Psych-DS requires data files to follow a specific naming pattern: `keyword-value_data.csv`. For example, `subject-01_data.csv` or `task-flanker_data.csv`.
+
+If your files don't already follow this pattern, the tool lists them and offers a menu of naming **strategies**:
+
+```
+2 data file(s) do not follow the Psych-DS naming pattern ([keyword-value_]+data.csv):
+    participant_01.csv
+    participant_02.csv
+
+Scanning 2 data file(s) for identifier columns…
+
+? How should these files be renamed?
+❯ Use the "subject_id" value found inside each file   (recommended)
+        Most reliable: the ID is read from the data itself, so it works even when the old filenames are meaningless.
+        participant_01.csv → subject-p01_data.csv
+        participant_02.csv → subject-p02_data.csv
+  Keep only the part that differs between the filenames
+  Give the files fresh numbered names (subject-001, subject-002, …)
+  Keep the whole old filename as the value
+```
+
+Each strategy shows a live preview of what it would produce, so you can judge the choice on your real filenames:
+
+| Strategy | What it does |
+|---|---|
+| **Use the value found inside each file** | Reads an ID column from the data (one unique value per file) and uses it as the value. Offered only when such a column exists in every file. The most reliable option — and the recommended one when available. |
+| **Keep only the part that differs** | Strips the shared prefix/suffix across the filenames and keeps the varying middle as the value (you'll pick the keyword next). Offered only when the names share a common pattern. |
+| **Give the files fresh numbered names** | Replaces messy names with a clean sequence (`subject-001`, `subject-002`, …). You type the first name; the rest continue the numbering. |
+| **Keep the whole old filename as the value** | The fallback, always available: squashes the entire old name into one value under a keyword you pick. Nothing is lost, but the names get verbose. |
+
+After picking a strategy you'll see the full set of proposed renames and choose what to do next:
+
+```
+Proposed renames:
+    participant_01.csv → subject-p01_data.csv
+    participant_02.csv → subject-p02_data.csv
+
+? Apply these names?
+❯ Apply
+  Edit one filename
+  Choose a different strategy
+```
+
+Choose **Apply** to write the names, **Edit one filename** to hand-tune a single name, or **Choose a different strategy** to go back. Name collisions are flagged and auto-adjusted in the preview before anything is written.
+
+> **If you prefer, rename your files before running the tool.** A compliant name looks like `subject-01_data.csv` — a keyword, a hyphen, a value, then `_data.csv`. Files that already follow this pattern are used as-is, with no prompt. (Files that use an *unofficial* keyword are technically valid but draw a validator warning; the tool offers to rename those too.)
+
+---
+
+### Step 6: Join keys for nested data (only if needed)
+
+Some jsPsych data contains **nested arrays** inside a trial (for example, per-keypress logs). Psych-DS stores these as separate CSV files, which need a column that uniquely identifies each row. If `trial_index` alone isn't unique, the tool asks you to add more columns:
+
+```
+⚠  [trial_index] not unique in "participant_01.csv": 12 duplicate rows found.
+   Nested arrays need a unique row ID to be saved as separate CSV files.
+   Suggested addition: [subject_id]
+
+? Select additional join-key columns for extracted array CSVs:
+ ── Sufficient alone ──
+❯◉ subject_id
+ ── Reduces duplicates ──
+ ◯ block
+ ──────────────
+ ◯ Proceed anyway (extracted CSVs may have duplicate rows)
+```
+
+Columns under **Sufficient alone** make every row unique by themselves; columns under **Reduces duplicates** help but may need to be combined. Pick the column(s) that identify a row, or choose **Proceed anyway** to skip. For JSON-Lines data with no per-trial id, the tool synthesizes a `source_record_id` (the line number) so nested data can still be split out — this marks the source record, not a real participant. Most flat datasets never see this prompt.
+
+---
+
+### Step 7: Customize metadata (optional)
+
+```
+? Would you like to customize the metadata?
+❯ Use defaults
+  Use a custom metadata file
+```
+
+The tool generates metadata automatically from your data files. If you want to add author names, a study description, or override variable descriptions, choose **Use a custom metadata file** and provide a path to a `.json` file. See [Metadata Options](metadata-options.md) for the format.
+
+Select **Use defaults** for now — you can always edit `dataset_description.json` directly later, or re-run the CLI and provide an options file at that point.
+
+---
+
+### Step 8: Fill in unknown variable descriptions (optional)
+
+After reading your data files, the tool tries to look up what each variable means by checking the jsPsych plugin that produced it. For variables it couldn't identify automatically, it will ask:
+
+```
+3 variable(s) have unknown descriptions. Would you like to fill them in?
+❯ Fill in descriptions   - You will be prompted for each variable. Press Enter to skip individual ones.
+  Skip                   - Leave descriptions as unknown in the dataset_description.json.
+```
+
+If you choose to fill them in, you'll see one prompt per variable. Press Enter to skip any you'd rather leave for later.
+
+---
+
+### Step 9: Validation
+
+The tool automatically checks your new project against the Psych-DS specification:
+
+```
+✔ Psych-DS validation passed (2 warnings).
+  (Rerun with --verbose to see warnings.)
+```
+
+A checkmark means your dataset is valid. Warnings are minor issues (like recommended fields that aren't filled in yet) — your dataset is still usable. If there are errors, the tool will describe them and may prompt you to fix required fields before finishing.
+
+---
+
+## What you get
+
+Your new project folder will be inside the location you chose in Step 2, named after the project name from Step 3. For example, if you chose `C:\Users\yourname\Documents\experiments` as the output location and `flanker-study` as the project name, the result is at `C:\Users\yourname\Documents\experiments\flanker-study\`:
+
+```
+flanker-study/
+├── data/
+│   ├── raw/
+│   │   ├── participant_01.csv        original files, untouched
+│   │   └── participant_02.csv
+│   ├── subject-p01_data.csv          Psych-DS normalized copies
+│   └── subject-p02_data.csv
+├── dataset_description.json          generated metadata
+├── README.md                         placeholder for a human-readable description
+└── CHANGES.md                        placeholder for a changelog
+```
+
+The `data/raw/` folder holds your original files exactly as they were. The `data/` folder holds the Psych-DS-compliant copies (JSON and JSON-Lines files are converted to CSV so the validator can read them).
+
+Open `dataset_description.json` to see what was generated. It will look something like:
+
+```json
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "name": "flanker-study",
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "name": "trial_type",
+      "description": "The name of the jsPsych plugin used to run the trial."
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "rt",
+      "description": "The response time in milliseconds for the participant to make a response."
+    }
+  ]
+}
+```
+
+---
+
+## Next steps
+
+- **Edit `dataset_description.json`** to add your name as an author, a study description, or other dataset-level fields.
+- **Edit `README.md`** inside your project to add a human-readable description of the experiment.
+- **Re-run the CLI** any time you add new data: use **Update an existing project** and point to your project folder — it will reload your existing metadata and incorporate the new files.
+- **Share or archive your project folder** — it's a self-contained, Psych-DS compliant dataset.
+
+For automating the tool in scripts (non-interactive mode, flags, exit codes), see the [CLI Reference](cli-reference.md). Prefer a point-and-click interface? See [Using the Web Wizard](using-the-frontend.md).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-This page documents all flags, exit codes, filename rules, and output behaviour for the jsPsych Metadata CLI. For a step-by-step walkthrough of a typical first run, see [Getting Started](getting-started.md).
+This page documents all flags, exit codes, filename rules, and output behaviour for the jsPsych Metadata CLI. For a step-by-step walkthrough of a typical first run, see the [CLI Guide](cli-guide.md).
 
 ---
 
@@ -73,9 +73,22 @@ fi
 
 ### Accepted formats
 
-The tool accepts `.csv` and `.json` data files produced by jsPsych. JSON files are automatically converted to CSV in the output (`data/` folder); the originals are preserved byte-for-byte in `data/raw/`. CSV files are copied to `data/` under their normalized name; originals are also preserved in `data/raw/`.
+The tool accepts the following jsPsych data shapes:
+
+| Format | Notes |
+|--------|-------|
+| **CSV** | One row per trial. Copied to `data/` under its normalized name. Unnamed row-index columns (the blank leading column some exporters and R add) are dropped. |
+| **JSON array** | The standard jsPsych export: `[ {…}, {…} ]`. Converted to CSV. |
+| **`{ "trials": [...] }` wrapper** | An object whose single key is `trials` holding the trial array (e.g. OSF exports). Automatically unwrapped, then treated as a JSON array. |
+| **JSON-Lines (`.jsonl`)** | One JSON value per line (JATOS and several labs export this way — often one participant's trial array per line). All lines are flattened into a single observation stream. |
+
+JSON and JSON-Lines files are automatically converted to CSV in the output (`data/` folder); the originals are preserved byte-for-byte in `data/raw/`. CSV files are copied to `data/` under their normalized name; originals are also preserved in `data/raw/`.
 
 Files of any other type are ignored during metadata generation.
+
+### Nested arrays and join keys
+
+When a data file contains nested arrays inside a trial, the tool extracts each array into its own Psych-DS CSV. Those rows need a column that uniquely identifies them. If `trial_index` alone isn't unique, the tool prompts (interactively) for additional **join-key** columns, grouping candidates into "Sufficient alone" and "Reduces duplicates", with a "Proceed anyway" escape. For JSON-Lines input with no per-trial identifier, a `source_record_id` (the source line) is synthesized so the join key can be formed; it marks the source record, not a real participant.
 
 ### Folder depth
 
@@ -103,12 +116,23 @@ data_2024-01-15.csv           ← date is not in keyword-value format
 flanker_results_data.csv      ← "flanker_results" is not a keyword-value pair
 ```
 
-In **interactive mode**, the tool detects non-compliant names and prompts you to choose a keyword. The file's current name becomes the value (with hyphens and underscores removed, since Psych-DS values may not contain them). For example:
+In **interactive mode**, the tool detects non-compliant names and offers a menu of naming **strategies**, each with a live preview of what it would produce on your actual filenames:
+
+| Strategy | What it does | When offered |
+|----------|--------------|--------------|
+| **Use the value found inside each file** | Reads an ID column from the data (one unique value per file) and uses it as the value. The most reliable option, and recommended when available. | Only when such a column exists in *every* file. |
+| **Keep only the part that differs** | Strips the shared prefix/suffix across filenames; the varying middle becomes the value (you pick the keyword). | Only when the filenames share a common pattern. |
+| **Give the files fresh numbered names** | Replaces names with a clean sequence (`subject-001`, `subject-002`, …); you type the first name. | Always. |
+| **Keep the whole old filename as the value** | The fallback: the entire old name becomes one value under a keyword you pick. Nothing is lost, but names get verbose. | Always. |
+
+After you pick a strategy, the tool shows the full set of proposed renames (including any sidecar CSVs from nested arrays, and auto-adjusting name collisions) and lets you **Apply**, **Edit one filename**, or **Choose a different strategy**. Psych-DS values may not contain hyphens or underscores, so those are stripped when a value is derived from a filename. For example:
 
 ```
 participant_01.csv → subject-participant01_data.csv
 flanker_results.json → task-flankerResults_data.csv
 ```
+
+Files with technically valid names that use an **unofficial keyword** (one not in the table below) are legal but draw a validator warning; the tool offers to rename those too.
 
 Official Psych-DS keywords offered by the tool:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,214 +1,46 @@
-# Getting Started: Organizing jsPsych Data with the Metadata CLI
+# Getting Started
 
-This guide walks you through using the jsPsych Metadata CLI to turn your raw experiment data into a [Psych-DS](https://psych-ds.github.io/) compliant dataset. By the end, you'll have a structured project folder with a `dataset_description.json` file that describes your experiment and its variables.
+This project generates [Psych-DS](https://psych-ds.github.io/) compliant metadata for [jsPsych](https://www.jspsych.org/) experiments. It reads your raw experiment data and produces a `dataset_description.json` that describes your experiment and its variables, so your data is easier to share, archive, and reuse.
+
+There are two ways to use it — both produce the same Psych-DS output. Pick whichever fits how you work.
 
 ## What is Psych-DS?
 
 [Psych-DS](https://psych-ds.github.io/) is a community standard for organizing and documenting psychology datasets. A Psych-DS compliant dataset has a predictable folder structure and a machine-readable description file (`dataset_description.json`) that travels with the data, making it easier to share, archive, and reuse — by collaborators, reviewers, or your future self.
 
-If you'd like more background before diving in, see [What is Psych-DS?](what-is-psych-ds.md).
+The hardest part of meeting the standard is writing that description file by hand. This tool automates it: it reads your jsPsych data files, figures out what each variable means by looking up the plugin that produced it, and writes the `dataset_description.json` for you.
 
-The Metadata CLI automates the most tedious part: generating the `dataset_description.json` by reading your jsPsych data files and looking up what each variable means.
+For more background, see [What is Psych-DS?](what-is-psych-ds.md).
 
-## Before you start
+## Two ways to use it
 
-You'll need:
+### 🌐 Web wizard — no install
 
-- **Node.js** installed on your computer (version 18 or later). You can check by running `node --version` in your terminal. If it's not installed, download it from [nodejs.org](https://nodejs.org).
-- **Your jsPsych data files** — CSV or JSON files produced by your experiment. These can be in one folder or organized into subfolders one level deep.
+A point-and-click wizard that runs entirely in your browser. Upload your data, fill in a few fields, and download a ready-to-share Psych-DS project — including in-browser validation. Nothing to install; nothing leaves your computer.
 
-## Running the tool
+→ **[Using the Web Wizard](using-the-frontend.md)**
 
-Open a terminal and run:
+### 💻 Command-line tool — for local folders and automation
 
-```
-npx @jspsych/metadata-cli
-```
+A terminal tool that reads a folder of data files and writes a Psych-DS project next to them. Best when your data already lives on your machine, or when you want to script metadata generation as part of a pipeline.
 
-The first time you run this, `npx` will download the tool automatically. After that it launches immediately.
+→ **[CLI Guide](cli-guide.md)** for a step-by-step walkthrough, and the **[CLI Reference](cli-reference.md)** for flags, exit codes, and non-interactive use.
 
----
+### Which should I pick?
 
-## Interactive walkthrough
+Use the **web wizard** if you want the quickest start with no setup. Use the **CLI** if your data is already in a local folder, or you need to run metadata generation unattended (in a script, on a schedule, or on a remote machine).
 
-The following steps use two example data files named `participant_01.csv` and `participant_02.csv`.
+## What you'll get
 
-### Step 1: Create a new project or update an existing one
+Either path produces a self-contained Psych-DS project folder:
 
 ```
-? What would you like to do?
-❯ Create a new project
-  Update an existing project
+your-project/
+├── data/                       your data files, in Psych-DS compliant CSV form
+│   └── raw/                     your original files, untouched
+├── dataset_description.json    the generated metadata
+├── README.md                   placeholder for a human-readable description
+└── CHANGES.md                  placeholder for a changelog
 ```
 
-Select **Create a new project** if this is the first time you're generating metadata for this dataset. Use **Update an existing project** if you've run the tool before and want to regenerate the metadata (for example, after collecting more data).
-
----
-
-### Step 2: Choose where to save the project
-
-```
-? Path to the folder where the new project will be created:
-```
-
-Enter the path to an existing folder — the tool will create a new subfolder inside it for your project. **The folder you enter here must already exist.**
-
-- **Windows:** `C:\Users\yourname\Documents\experiments`
-- **Mac / Linux:** `/Users/yourname/Documents/experiments` or `~/experiments`
-
-On Windows, you can copy the path directly from File Explorer's address bar. On Mac, you can drag a folder into the terminal window to paste its path. The `~` character is a shortcut for your home folder on Mac and Linux.
-
----
-
-### Step 3: Name your project
-
-```
-? Enter the project name (used as the folder name and in the metadata): flanker-study
-```
-
-The name becomes the subfolder created inside the folder from Step 2, and is recorded in the metadata. Use something descriptive without spaces (hyphens are fine).
-
----
-
-### Step 4: Point to your data
-
-```
-? Path to your raw data folder (files will be copied, not moved):
-```
-
-Enter the path to the folder containing your jsPsych data files. Use the same path format as Step 2 — the full path to an existing folder on your computer. Your original files are never modified; the tool copies them into the new project.
-
----
-
-### Step 5: File naming (if your files need renaming)
-
-Psych-DS requires data files to follow a specific naming pattern: `keyword-value_data.csv`. For example, `subject-01_data.csv` or `task-flanker_data.csv`.
-
-If your files don't already follow this pattern, the tool will tell you and ask how to label them:
-
-```
-2 data file(s) do not follow the Psych-DS naming pattern ([keyword-value_]+data.csv):
-    participant_01.csv
-    participant_02.csv
-
-? Choose a Psych-DS keyword to label these files (their current name becomes the value):
-❯ subject   - The participant/subject the data belongs to
-  session   - A session of data collection
-  task      - The task in which the data was collected
-  condition - The experimental condition
-  trial     - The trial the data belongs to
-  stimulus  - The stimulus item
-  study     - The study the data belongs to
-  site      - The site where the data was collected
-  description - A free-form label describing the file
-  ──────────────
-  Other (custom keyword)
-```
-
-Choose the keyword that best describes what your filenames refer to. Since these files are named by participant, select **subject**:
-
-```
-    participant_01.csv → subject-participant01_data.csv
-    participant_02.csv → subject-participant02_data.csv
-```
-
-The part after the hyphen is your original filename with hyphens and underscores removed (Psych-DS values don't allow them).
-
-> **If you prefer, rename your files before running the tool.** A compliant name looks like `subject-01_data.csv` — a keyword, a hyphen, a value, then `_data.csv`. Files that already follow this pattern are used as-is, with no prompt.
-
----
-
-### Step 6: Customize metadata (optional)
-
-```
-? Would you like to customize the metadata?
-❯ Use defaults
-  Use a custom metadata file
-```
-
-The tool generates metadata automatically from your data files. If you want to add author names, a study description, or override variable descriptions, choose **Use a custom metadata file** and provide a path to a `.json` file. See [Metadata Options](metadata-options.md) for the format.
-
-Select **Use defaults** for now — you can always edit `dataset_description.json` directly later, or re-run the CLI and provide an options file at that point.
-
----
-
-### Step 7: Fill in unknown variable descriptions (optional)
-
-After reading your data files, the tool tries to look up what each variable means by checking the jsPsych plugin that produced it. For variables it couldn't identify automatically, it will ask:
-
-```
-3 variable(s) have unknown descriptions. Would you like to fill them in?
-❯ Fill in descriptions   - You will be prompted for each variable. Press Enter to skip individual ones.
-  Skip                   - Leave descriptions as unknown in the dataset_description.json.
-```
-
-If you choose to fill them in, you'll see one prompt per variable. Press Enter to skip any you'd rather leave for later.
-
----
-
-### Step 8: Validation
-
-The tool automatically checks your new project against the Psych-DS specification:
-
-```
-✔ Psych-DS validation passed (2 warnings).
-  (Rerun with --verbose to see warnings.)
-```
-
-A checkmark means your dataset is valid. Warnings are minor issues (like recommended fields that aren't filled in yet) — your dataset is still usable. If there are errors, the tool will describe them and may prompt you to fix required fields before finishing.
-
----
-
-## What you get
-
-Your new project folder will be inside the location you chose in Step 2, named after the project name from Step 3. For example, if you chose `C:\Users\yourname\Documents\experiments` as the output location and `flanker-study` as the project name, the result is at `C:\Users\yourname\Documents\experiments\flanker-study\`:
-
-```
-flanker-study/
-├── data/
-│   ├── raw/
-│   │   ├── participant_01.csv        original files, untouched
-│   │   └── participant_02.csv
-│   ├── subject-participant01_data.csv   Psych-DS normalized copies
-│   └── subject-participant02_data.csv
-├── dataset_description.json             generated metadata
-├── README.md                            placeholder for a human-readable description
-└── CHANGES.md                           placeholder for a changelog
-```
-
-The `data/raw/` folder holds your original files exactly as they were. The `data/` folder holds the Psych-DS-compliant copies (JSON files are converted to CSV so the validator can read them).
-
-Open `dataset_description.json` to see what was generated. It will look something like:
-
-```json
-{
-  "@context": "https://schema.org/",
-  "@type": "Dataset",
-  "name": "flanker-study",
-  "variableMeasured": [
-    {
-      "@type": "PropertyValue",
-      "name": "trial_type",
-      "description": "The name of the jsPsych plugin used to run the trial."
-    },
-    {
-      "@type": "PropertyValue",
-      "name": "rt",
-      "description": {
-        "jsPsych-html-keyboard-response": "The response time in milliseconds..."
-      }
-    }
-  ]
-}
-```
-
----
-
-## Next steps
-
-- **Edit `dataset_description.json`** to add your name as an author, a study description, or other dataset-level fields.
-- **Edit `README.md`** inside your project to add a human-readable description of the experiment.
-- **Re-run the CLI** any time you add new data: use **Update an existing project** and point to your project folder — it will reload your existing metadata and incorporate the new files.
-- **Share or archive your project folder** — it's a self-contained, Psych-DS compliant dataset.
-
-For automating the tool in scripts, see [CLI Reference](cli-reference.md).
+Both tools accept jsPsych data as CSV, JSON, or JSON-Lines (`.jsonl`), and convert JSON/JSONL to CSV so the Psych-DS validator can read it. Your originals are always preserved under `data/raw/`.

--- a/docs/using-the-frontend.md
+++ b/docs/using-the-frontend.md
@@ -80,8 +80,7 @@ Inspect the generated `dataset_description.json` and download your project:
       └── <your data files>
   ```
 - If no data files were uploaded, a **Save `dataset_description.json`** button is shown instead.
-- **Validate dataset** runs the Psych-DS validator entirely in your browser and lists any errors and warnings inline, each with the underlying rule key and the specific files/columns at fault. **An internet connection is required** — the validator fetches the Psych-DS schema and schema.org context at runtime.
-  - Because in-browser validation only sees your metadata and data files, it may report missing `README` / `CHANGES` warnings. These are expected: the downloaded zip already includes `README.md` and `CHANGES.md`, so they clear when you validate the downloaded dataset (e.g. with `npx @jspsych/cli validate`).
+- **Validate dataset** runs the Psych-DS validator entirely in your browser (an internet connection is required) and lists any errors and warnings inline. Missing `README` / `CHANGES` warnings are expected here — the downloaded zip includes both files, so they clear when you validate the downloaded dataset (e.g. with `npx @jspsych/cli validate`). See the [frontend README](../packages/frontend/README.md#step-5--review) and the [frontend developer guide](dev/frontend-architecture.md) for the full validation flow.
 
 The **{} Preview** pill button (visible on all steps except Review) opens a live JSON snapshot in a slide-in drawer, so you can check the output at any point without leaving the current step.
 

--- a/docs/using-the-frontend.md
+++ b/docs/using-the-frontend.md
@@ -1,0 +1,94 @@
+# Using the Web Wizard
+
+A browser-based wizard for generating [Psych-DS](https://psych-ds.github.io/) compliant `dataset_description.json` files from jsPsych experiment data. It mirrors the functionality of the [CLI](cli-guide.md) in a point-and-click interface — nothing to install, and your data never leaves your computer.
+
+If you're not sure whether the wizard or the CLI is right for you, start with [Getting Started](getting-started.md).
+
+> **Note:** for running the wizard locally during development and for its internal architecture, see the [frontend package README](../packages/frontend/README.md) and the [frontend developer guide](dev/frontend-architecture.md).
+
+---
+
+## Welcome screen
+
+Choose one of two starting points:
+
+- **Create new project** — start from scratch. The wizard walks you through each step and produces a downloadable Psych-DS project.
+- **Open existing project** — upload an existing `dataset_description.json` to continue editing, or to update the metadata after adding new data files.
+
+A **☾ Dark / ☀ Light** toggle in the top-right corner switches the colour theme. Your choice is remembered across sessions.
+
+---
+
+## Step 1 — Project Info
+
+Fill in basic information about your dataset:
+
+- **Project name** *(required)* — used as the dataset identifier and as the downloaded folder name.
+- **Description** — a plain-English summary of the experiment. Defaults to "No description provided." if left blank.
+- **License, funding source, keywords, citation** *(optional)* — additional Psych-DS recommended fields.
+
+You can also upload an existing `dataset_description.json` here to pre-fill all fields, with a before/after comparison when the uploaded values differ from anything you've already entered.
+
+---
+
+## Step 2 — Data
+
+Upload your jsPsych data files:
+
+- Click **Choose folder** to browse for a directory (uses the browser's folder picker) **or** click **Upload zip** to upload a `.zip` containing your data files.
+- Each file is shown with a status indicator once processed.
+- Accepted formats: **CSV**, **JSON arrays**, the **`{ "trials": [...] }` wrapper** (e.g. OSF exports), and **JSON-Lines (`.jsonl`)**. JSON and JSONL are converted to Psych-DS-named CSV (e.g. `data/subject-sub01_data.csv`) so the validator and the downloaded zip both see compliant tables; your originals are preserved under `data/raw/`. CSV uploads are kept as-is.
+- If your data files contain **nested arrays**, the wizard checks whether `trial_index` uniquely identifies each row. If not, a **join-key chooser** lets you select additional columns before proceeding — these are used to name the separate CSV files the validator expects.
+
+> **For existing projects:** the Data step is pre-marked complete since your variables are already loaded from the uploaded `dataset_description.json`. You can still upload new data files to regenerate the variable list.
+
+---
+
+## Step 3 — Variables
+
+Review and annotate each variable detected in your data:
+
+- Variables with **unknown descriptions** (those the plugin lookup couldn't fill in automatically) appear in an expanded section at the top.
+- Known variables start collapsed. Use **Expand all / Collapse all** to open or close all rows at once.
+- Each row has a **Description** text area and a **Type** dropdown. Editing either updates the metadata immediately.
+- Long level lists are truncated at five entries with a **Show all N** toggle.
+
+---
+
+## Step 4 — Authors
+
+Add contributors to the dataset:
+
+- Click **Add author** to create a new row. Type a name and press Tab or click away to commit it.
+- Expand a row to fill in optional fields: given name, family name, author type, ORCID.
+- **Bulk import** lets you paste a list of names (one per line, optionally followed by an ORCID) to add multiple authors at once. Invalid ORCIDs are flagged with a warning banner.
+
+---
+
+## Step 5 — Review
+
+Inspect the generated `dataset_description.json` and download your project:
+
+- The JSON viewer shows a syntax-highlighted, collapsible preview of the output.
+- Click **Download `<project-name>.zip`** to download a complete Psych-DS project archive:
+  ```
+  <project-name>.zip
+  ├── dataset_description.json
+  ├── README.md
+  ├── CHANGES.md
+  └── data/
+      └── <your data files>
+  ```
+- If no data files were uploaded, a **Save `dataset_description.json`** button is shown instead.
+- **Validate dataset** runs the Psych-DS validator entirely in your browser and lists any errors and warnings inline, each with the underlying rule key and the specific files/columns at fault. **An internet connection is required** — the validator fetches the Psych-DS schema and schema.org context at runtime.
+  - Because in-browser validation only sees your metadata and data files, it may report missing `README` / `CHANGES` warnings. These are expected: the downloaded zip already includes `README.md` and `CHANGES.md`, so they clear when you validate the downloaded dataset (e.g. with `npx @jspsych/cli validate`).
+
+The **{} Preview** pill button (visible on all steps except Review) opens a live JSON snapshot in a slide-in drawer, so you can check the output at any point without leaving the current step.
+
+---
+
+## Next steps
+
+- **Unzip and share** your downloaded project — it's a self-contained, Psych-DS compliant dataset.
+- Need to script metadata generation, or already have your data in a local folder? See the [CLI Guide](cli-guide.md).
+- Want to customize variable descriptions or authors from a file? See [Metadata Options](metadata-options.md).


### PR DESCRIPTION
## PR 1 — Reorganize & refresh the existing user guides

The `docs/` user-facing pages were written before several features landed and were partly stale, and the browser wizard had no discoverable user docs under `docs/`. This PR tidies, migrates, and updates **existing** content only — no new tooling.

### Structure

| File | Change |
|------|--------|
| `docs/getting-started.md` | **Rewritten** as a short, tool-agnostic overview ("two ways to use it": web wizard vs. CLI) that branches to the right page. |
| `docs/cli-guide.md` | **New.** The step-by-step CLI walkthrough, moved out of getting-started and refreshed. |
| `docs/using-the-frontend.md` | **New.** User-facing web wizard guide (Welcome + Steps 1–5), adapted from the frontend README. |
| `docs/cli-reference.md` | **Updated.** Accepted formats, naming strategies, join keys, cross-links. |

### Refreshed for currently-implemented behavior

- **Input formats:** JSON arrays, **JSON-Lines (`.jsonl`)**, and the **`{ "trials": [...] }`** wrapper (e.g. OSF exports); unnamed row-index column dropping.
- **Smart rename:** the old single "choose a keyword" prompt is replaced by the real **strategy menu** (read-ID-from-data / pattern / sequential / keyword+full-stem fallback) with the preview → apply / edit / back loop.
- **Nested arrays:** the **join-key** prompt (and synthesized `source_record_id` for JSONL).
- **Validation:** in-browser "Validate dataset" + the README/CHANGES zip-resolved-warnings note.

### Notes

- `packages/frontend/README.md` is left as the dev/local-run source of truth, with see-also links to/from the new docs page.
- Flags/aliases/exit codes in `cli-reference.md` verified against `index.ts` — no drift.
- Verified no dead `getting-started.md` links; corrected a stale `description` example (object → collapsed string, per #105).
- Docs-only change — no changeset (no package version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)