### PR TITLE
docs: fix review issues and expand web wizard guide

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -19,7 +19,7 @@ With no flags, the tool runs interactively and prompts you for everything it nee
 | Flag | Alias | Type | Description |
 |------|-------|------|-------------|
 | `--psych-ds-dir` | `-em` | path | Path to an **existing** Psych-DS project folder. Must contain a `dataset_description.json`. Use this when updating a project you have already generated. |
-| `--data-dir` | `-d` | path | Path to the folder containing your raw jsPsych data files (`.csv` or `.json`). |
+| `--data-dir` | `-d` | path | Path to the folder containing your raw jsPsych data files (`.csv`, `.json`, or `.jsonl`). |
 | `--metadata-options` | `-m` | path | Path to a metadata options `.json` file. See [Metadata Options](metadata-options.md). |
 | `--verbose` | `-v` | boolean | Print detailed output at each processing step. Shows plugin fetching, variable resolution, and full validation warnings. |
 

--- a/docs/using-the-frontend.md
+++ b/docs/using-the-frontend.md
@@ -38,7 +38,13 @@ Upload your jsPsych data files:
 - Click **Choose folder** to browse for a directory (uses the browser's folder picker) **or** click **Upload zip** to upload a `.zip` containing your data files.
 - Each file is shown with a status indicator once processed.
 - Accepted formats: **CSV**, **JSON arrays**, the **`{ "trials": [...] }` wrapper** (e.g. OSF exports), and **JSON-Lines (`.jsonl`)**. JSON and JSONL are converted to Psych-DS-named CSV (e.g. `data/subject-sub01_data.csv`) so the validator and the downloaded zip both see compliant tables; your originals are preserved under `data/raw/`. CSV uploads are kept as-is.
-- If your data files contain **nested arrays**, the wizard checks whether `trial_index` uniquely identifies each row. If not, a **join-key chooser** lets you select additional columns before proceeding — these are used to name the separate CSV files the validator expects.
+- If your data files contain **nested arrays**, the wizard checks whether `trial_index` uniquely identifies each row. If not, a **join-key chooser** appears before processing continues.
+
+  **What is a join key?** jsPsych experiments sometimes produce nested data — for example, a survey trial might contain multiple responses stored as an array inside a single row. To save this as a flat table (CSV), each nested item needs to be matched back to its parent row. A join key is a column (or combination of columns) whose values are unique for every row. `trial_index` works fine for single-participant files, but if you merged data from multiple participants, each participant resets `trial_index` to 0 — making it non-unique.
+
+  In the chooser, `trial_index` is pre-selected. Additional candidate columns are listed below it; columns tagged **sufficient alone** make every row unique on their own (typically `source_record_id` or `participant_id`). Select one or more until the combination uniquely identifies each row, then click **Apply and process files**. If no combination works, check **Proceed anyway** — extracted CSVs may contain duplicate rows, but you can still continue.
+
+  Once files are processed, a **Re-configure join keys** button remains available on the Data step if you need to change your selection.
 
 > **For existing projects:** the Data step is pre-marked complete since your variables are already loaded from the uploaded `dataset_description.json`. You can still upload new data files to regenerate the variable list.
 

--- a/docs/using-the-frontend.md
+++ b/docs/using-the-frontend.md
@@ -80,7 +80,7 @@ Inspect the generated `dataset_description.json` and download your project:
       └── <your data files>
   ```
 - If no data files were uploaded, a **Save `dataset_description.json`** button is shown instead.
-- **Validate dataset** runs the Psych-DS validator entirely in your browser (an internet connection is required) and lists any errors and warnings inline. Missing `README` / `CHANGES` warnings are expected here — the downloaded zip includes both files, so they clear when you validate the downloaded dataset (e.g. with `npx @jspsych/cli validate`). See the [frontend README](../packages/frontend/README.md#step-5--review) and the [frontend developer guide](dev/frontend-architecture.md) for the full validation flow.
+- **Validate dataset** runs the Psych-DS validator entirely in your browser (an internet connection is required) and lists any errors and warnings inline. Missing `README` / `CHANGES` warnings are expected here — the downloaded zip includes both files, so they clear when you validate the unzipped folder using the [Psych-DS web validator](https://psych-ds.github.io/validator/). See the [frontend README](../packages/frontend/README.md#step-5--review) and the [frontend developer guide](dev/frontend-architecture.md) for the full validation flow.
 
 The **{} Preview** pill button (visible on all steps except Review) opens a live JSON snapshot in a slide-in drawer, so you can check the output at any point without leaving the current step.
 

--- a/docs/what-is-psych-ds.md
+++ b/docs/what-is-psych-ds.md
@@ -70,6 +70,7 @@ Metadata generation isn't a separate tool you have to bolt on afterward — it d
 - **In the browser, alongside your experiment.** The `@jspsych/metadata` library runs client-side, so an experiment can generate or update its own `dataset_description.json` at the moment data is collected, using the plugins it already loaded.
 - **In Node or a build step.** The same library runs server-side to process data you've already collected, in batch.
 - **From the command line.** The Metadata CLI wraps that library for researchers who just want to point at a folder of files.
+- **Via the web wizard.** A point-and-click interface that runs the same process in your browser, with no installation required. See [Using the Web Wizard](using-the-frontend.md).
 
 In every case the variable descriptions come from the **same jsPsych plugin modules your experiment uses**. Because the plugin is the source of truth, the descriptions stay consistent with the plugin versions you actually ran — there's no separate data dictionary to maintain by hand.
 


### PR DESCRIPTION
Follow-up to #127, which merged before these corrections could be included. Also expands the join key explanation in the web wizard guide, which was previously a single undescribed sentence.

## Changes

- **`using-the-frontend.md`**: replace the non-existent `npx @jspsych/cli validate` command with a link to the [Psych-DS web validator](https://psych-ds.github.io/validator/)
- **`using-the-frontend.md`**: expand the join-key section in Step 2 — explain the concept, how to use the column chooser (including the "sufficient alone" tag and proceed-anyway fallback), and the re-configure button available after processing
- **`cli-reference.md`**: add `.jsonl` to the `--data-dir` flag description
- **`what-is-psych-ds.md`**: add a web wizard bullet to the "where it runs" list

Docs-only — no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)