### PR TITLE
docs(cli): slim package README + correct CLI guide/reference

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -70,10 +70,10 @@ On Windows, you can copy the path directly from File Explorer's address bar. On 
 ### Step 3: Name your project
 
 ```
-? Enter the project name (used as the folder name and in the metadata): flanker-study
+? Enter the project name (used as the folder name and in the metadata): my-experiment
 ```
 
-The name becomes the subfolder created inside the folder from Step 2, and is recorded in the metadata. Use something descriptive without spaces (hyphens are fine).
+The name becomes the subfolder created inside the folder from Step 2, and is recorded in the metadata. Use something descriptive without spaces (hyphens are fine). `my-experiment` here is just an example — use whatever name fits your study; the rest of this guide uses `my-experiment` to illustrate the output.
 
 ---
 
@@ -203,22 +203,21 @@ A checkmark means your dataset is valid. Warnings are minor issues (like recomme
 
 ## What you get
 
-Your new project folder will be inside the location you chose in Step 2, named after the project name from Step 3. For example, if you chose `C:\Users\yourname\Documents\experiments` as the output location and `flanker-study` as the project name, the result is at `C:\Users\yourname\Documents\experiments\flanker-study\`:
+Your new project folder will be inside the location you chose in Step 2, named after the project name from Step 3. For example, if you chose `C:\Users\yourname\Documents\experiments` as the output location and `my-experiment` as the project name, the result is at `C:\Users\yourname\Documents\experiments\my-experiment\`:
 
 ```
-flanker-study/
+my-experiment/
 ├── data/
-│   ├── raw/
-│   │   ├── participant_01.csv        original files, untouched
-│   │   └── participant_02.csv
-│   ├── subject-p01_data.csv          Psych-DS normalized copies
+│   ├── subject-p01_data.csv          Psych-DS compliant copies of your data
 │   └── subject-p02_data.csv
 ├── dataset_description.json          generated metadata
 ├── README.md                         placeholder for a human-readable description
 └── CHANGES.md                        placeholder for a changelog
 ```
 
-The `data/raw/` folder holds your original files exactly as they were. The `data/` folder holds the Psych-DS-compliant copies (JSON and JSON-Lines files are converted to CSV so the validator can read them).
+The `data/` folder holds the Psych-DS-compliant copies of your data. The example above starts from CSV files, which are already tabular and so are written straight to `data/`.
+
+If your inputs are **JSON or JSON-Lines**, the tool converts them to CSV in `data/` and additionally preserves your originals untouched under a `data/raw/` folder, alongside a top-level `.psychds-ignore` file that tells the validator to skip the raw copies. (CSV inputs aren't duplicated under `raw/`, so a CSV-only dataset has no `data/raw/` folder.) Data files that contain **nested arrays** produce one extra CSV per nested column.
 
 Open `dataset_description.json` to see what was generated. It will look something like:
 
@@ -226,7 +225,7 @@ Open `dataset_description.json` to see what was generated. It will look somethin
 {
   "@context": "https://schema.org/",
   "@type": "Dataset",
-  "name": "flanker-study",
+  "name": "my-experiment",
   "variableMeasured": [
     {
       "@type": "PropertyValue",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -44,10 +44,11 @@ npx @jspsych/metadata-cli \
 
 Non-interactive mode enforces stricter rules than interactive mode:
 
-- **Non-compliant filenames are a hard error.** In interactive mode, the tool prompts you to choose a keyword to bring non-compliant filenames into the Psych-DS naming pattern. In non-interactive mode, a non-compliant filename causes the tool to exit immediately with an error message and exit code 1. Rename your files before running (see [Data file naming](#data-file-naming) below).
+- **Non-compliant filenames are a hard error.** In interactive mode, the tool offers a menu of renaming strategies to bring non-compliant filenames into the Psych-DS naming pattern. In non-interactive mode, a non-compliant filename causes the tool to exit immediately with an error message and exit code 1. Rename your files before running (see [Data file naming](#data-file-naming) below).
 - **Unknown variable descriptions are not prompted.** Variables the tool cannot automatically describe are left as `"unknown"` in the output.
+- **Join keys are resolved automatically.** When nested-array rows aren't uniquely identified by `trial_index`, the tool picks the keys deterministically instead of prompting, and reports the choice (see [Nested arrays and join keys](#nested-arrays-and-join-keys)).
 
-Non-interactive mode is useful for running the tool on a schedule, in a script, or on a remote machine.
+The tool also runs without prompting whenever it isn't attached to an interactive terminal (for example, piped output or a CI job), even if you omit some flags. In that case it keeps the generated metadata defaults unless `--metadata-options` is supplied. Non-interactive mode is useful for running the tool on a schedule, in a script, or on a remote machine.
 
 ---
 
@@ -82,13 +83,13 @@ The tool accepts the following jsPsych data shapes:
 | **`{ "trials": [...] }` wrapper** | An object whose single key is `trials` holding the trial array (e.g. OSF exports). Automatically unwrapped, then treated as a JSON array. |
 | **JSON-Lines (`.jsonl`)** | One JSON value per line (JATOS and several labs export this way — often one participant's trial array per line). All lines are flattened into a single observation stream. |
 
-JSON and JSON-Lines files are automatically converted to CSV in the output (`data/` folder); the originals are preserved byte-for-byte in `data/raw/`. CSV files are copied to `data/` under their normalized name; originals are also preserved in `data/raw/`.
+JSON and JSON-Lines files are automatically converted to CSV in the output (`data/` folder); the originals are preserved byte-for-byte under `data/raw/`, and a top-level `.psychds-ignore` is written so the validator skips that raw copy. CSV files are written to `data/` under their normalized name; because they are already tabular, CSV inputs are **not** duplicated under `data/raw/` (so a CSV-only dataset has no `data/raw/` folder).
 
 Files of any other type are ignored during metadata generation.
 
 ### Nested arrays and join keys
 
-When a data file contains nested arrays inside a trial, the tool extracts each array into its own Psych-DS CSV. Those rows need a column that uniquely identifies them. If `trial_index` alone isn't unique, the tool prompts (interactively) for additional **join-key** columns, grouping candidates into "Sufficient alone" and "Reduces duplicates", with a "Proceed anyway" escape. For JSON-Lines input with no per-trial identifier, a `source_record_id` (the source line) is synthesized so the join key can be formed; it marks the source record, not a real participant.
+When a data file contains nested arrays inside a trial, the tool extracts each array into its own Psych-DS CSV. Those rows need a column that uniquely identifies them. If `trial_index` alone isn't unique, the tool prompts (interactively) for additional **join-key** columns, grouping candidates into "Sufficient alone" and "Reduces duplicates", with a "Proceed anyway" escape. In a non-interactive run there is nothing to prompt, so the keys are resolved automatically and the choice is reported in the output. For JSON-Lines input with no per-trial identifier, a `source_record_id` (the source line) is synthesized so the join key can be formed; it marks the source record, not a real participant.
 
 ### Folder depth
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,143 +2,42 @@
 
 A command-line tool for generating [Psych-DS](https://psych-ds.github.io/) compliant metadata for jsPsych experiments. Given a folder of jsPsych data files, it produces a `dataset_description.json` that describes your experiment and its variables according to the Psych-DS standard.
 
----
-
-## What is Psych-DS?
-
-[Psych-DS](https://psych-ds.github.io/) is a community standard for organizing and documenting psychology datasets. A Psych-DS compliant project has a predictable folder structure and a `dataset_description.json` file that describes the dataset, its authors, and the variables it contains. This makes your data easier to share, reproduce, and understand.
-
----
-
 ## Quick start
+
+**Node.js 18 or later is required.** Check with `node --version`; if you don't have it, install it from [nodejs.org](https://nodejs.org).
 
 ```
 npx @jspsych/metadata-cli
 ```
 
-Running the tool without any flags launches the interactive mode, which walks you through each step. This is the recommended way to use the tool.
-
----
-
-## Interactive walkthrough
-
-When you run the CLI interactively, it guides you through the following steps:
-
-### 1. Create a new project or update an existing one
-
-You will be asked whether you want to:
-
-- **Create a new project** — the tool creates a new Psych-DS folder structure and generates metadata from scratch.
-- **Update an existing project** — point the tool to a folder that already contains a `dataset_description.json` and it will load the existing metadata before updating it.
-
-### 2. Project name (new projects only)
-
-If creating a new project, you will be asked for a project name. This is used as the subfolder name and is written into the metadata.
-
-### 3. Path to your data folder
-
-Provide the path to the folder containing your jsPsych data files (`.csv` or `.json`). The tool reads one level of subdirectories. Your files will be **copied** into a `data/` subfolder inside the new project — your originals are not modified.
-
-### 4. Customize metadata (optional)
-
-You can optionally provide a metadata options file (see [Metadata options file](#metadata-options-file) below) to set fields like author names, variable descriptions, and other dataset-level information. If you skip this step you can always edit `dataset_description.json` directly or re-run the CLI later.
-
-### 5. Fill in unknown variable descriptions (optional)
-
-After processing your data files, the tool will flag any variables whose descriptions could not be automatically determined (for example, variables from custom plugins). You can type in descriptions for each one or press Enter to skip.
-
-### 6. Validation
-
-After saving, the tool validates the project against the Psych-DS specification and reports whether it passed, along with any errors or warnings.
-
----
-
-## Generated project structure
-
-For a new project named `my-experiment`, the tool creates:
+Running the tool without any flags launches interactive mode, which walks you through each step — the recommended way to use it. Point it at a folder of jsPsych data files (`.csv`, `.json`, or `.jsonl`) and it builds a self-contained Psych-DS project:
 
 ```
 my-experiment/
-├── data/                         # copies of your raw data files
-├── dataset_description.json      # generated Psych-DS metadata
-├── README.md                     # placeholder for a human-readable description
-└── CHANGES.md                    # placeholder for version tracking
+├── data/                         Psych-DS compliant CSV copies of your data
+│   └── raw/                       your original files, untouched
+├── dataset_description.json      generated Psych-DS metadata
+├── README.md                     placeholder for a human-readable description
+└── CHANGES.md                    placeholder for version tracking
 ```
 
----
+## Documentation
 
-## Flags and non-interactive mode
+The full guides live in the repository's [`docs/`](../../docs) folder:
 
-All prompting steps can be skipped by passing the corresponding flags directly. If all three path flags are provided and valid, the tool runs fully non-interactively.
+- **[Getting Started](../../docs/getting-started.md)** — overview and which tool to use (CLI vs. the browser wizard).
+- **[CLI Guide](../../docs/cli-guide.md)** — step-by-step walkthrough of an interactive run, accepted data formats, and file-renaming strategies.
+- **[CLI Reference](../../docs/cli-reference.md)** — every flag, exit code, filename rule, and non-interactive (scripting) usage.
+- **[Metadata Options](../../docs/metadata-options.md)** — the optional `.json` file for setting authors, descriptions, and other fields.
+- **[What is Psych-DS?](../../docs/what-is-psych-ds.md)** — background on the standard.
 
-```
-npx @jspsych/metadata-cli --psych-ds-dir=/path/to/existing/project --data-dir=/path/to/data --metadata-options=/path/to/options.json
-```
+## Running the CLI locally (development)
 
-| Flag | Alias | Description |
-|------|-------|-------------|
-| `--psych-ds-dir` | `-em` | Path to an existing Psych-DS project folder (must contain `dataset_description.json`). Use this to update existing metadata. |
-| `--data-dir` | `-d` | Path to the folder containing your jsPsych data files. |
-| `--metadata-options` | `-m` | Path to a metadata options `.json` file to customise the generated metadata. |
-| `--verbose` | `-v` | Print detailed output at each step. Useful for debugging. |
-
-If a flag is provided but invalid, the tool will fall back to prompting for that step.
-
----
-
-## Metadata options file
-
-A metadata options file is a `.json` file that lets you set or override fields in the generated metadata. Any top-level key maps directly to a field in `dataset_description.json`. Authors and variables require a nested structure.
-
-### Example
-
-```json
-{
-  "name": "My Experiment",
-  "description": "A study on response times.",
-  "author": {
-    "Jane Smith": {
-      "name": "Jane Smith",
-      "givenName": "Jane",
-      "familyName": "Smith"
-    }
-  },
-  "variables": {
-    "rt": {
-      "description": {
-        "my-plugin": "Reaction time in milliseconds."
-      }
-    }
-  }
-}
-```
-
----
-
-## Data file requirements
-
-- Files must be `.csv` or `.json` format generated by jsPsych.
-- The tool reads all files in the target folder and one level of subdirectories.
-- If a `dataset_description.json` is present in the data folder it will be loaded as existing metadata rather than treated as a data file.
-- Non-data files in the folder will be counted as failures but will not prevent the rest of the files from being processed.
-
----
-
-## Running the CLI locally
-
-For development or customisation, you can run the CLI directly from the source:
+To run the CLI from source — for development or to modify it:
 
 1. Clone the repository.
-2. Navigate to `packages/cli`.
-3. Run `npm install`.
-4. Run `npm run build`.
-5. Run `npx .` to launch the CLI.
+2. From the repo root, run `npm install`.
+3. `cd packages/cli` and run `npm run build`.
+4. Run `npx .` to launch the CLI.
 
-Node.js must be installed. This is only recommended if you have programming experience and want to modify the tool.
-
----
-
-## Naming requirements
-
-- The metadata file must be named exactly `dataset_description.json`.
-- Data files must be `.csv` or `.json`. Other file types will not be processed.
+See the [developer guide](../../docs/dev/cli-architecture.md) for the internal architecture.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,11 +15,13 @@ Running the tool without any flags launches interactive mode, which walks you th
 ```
 my-experiment/
 ├── data/                         Psych-DS compliant CSV copies of your data
-│   └── raw/                       your original files, untouched
+│   └── raw/                       JSON/JSONL inputs only: your originals, untouched
 ├── dataset_description.json      generated Psych-DS metadata
 ├── README.md                     placeholder for a human-readable description
 └── CHANGES.md                    placeholder for version tracking
 ```
+
+CSV inputs are already tabular, so they're written straight to `data/`; only JSON and JSON-Lines inputs are converted to CSV and additionally preserved under `data/raw/`. A CSV-only dataset has no `data/raw/` folder.
 
 ## Documentation
 


### PR DESCRIPTION
## PR 2 — CLI docs follow-up (stacked on #127)

Stacked on `docs/reorganize-user-guides` (#127). Base that PR first; this one shows only the CLI-specific changes.

### `packages/cli/README.md` — slimmed to intro + links
Removed the walkthrough, flags table, metadata-options example, and data-file requirements that now duplicate `docs/cli-guide.md` and `docs/cli-reference.md`. Kept a quick start (with the Node.js prerequisite up front), a project-structure sketch, a **Documentation** section linking to the `docs/` guides, and the dev "run locally" note. 144 → ~45 lines.

### `docs/cli-guide.md` + `docs/cli-reference.md` — accuracy corrections
Reviewed both against the current CLI implementation and made targeted fixes:

- **CSV originals are not duplicated under `data/raw/`.** CSVs are copied to `data/` (their final tabular form is the preserved copy); only JSON/JSONL originals are kept under `data/raw/`. The old "What you get" tree wrongly showed the CSV example files under `raw/`. (`cli/src/data.ts:421` — raw block is gated on `if (parsed)`, set only for JSON/JSONL.)
- **`.psychds-ignore`** — documented the top-level file written when raw originals are preserved (`data.ts:554-559`), plus that nested arrays produce sidecar CSVs.
- **`--data-dir`** accepts `.csv`, `.json`, or `.jsonl` (was "`.csv` or `.json`"; `data.ts:12-13`).
- **Non-interactive behavior** — join keys are resolved automatically (no prompt; `index.ts:742-749`), and the tool also runs without prompting when not attached to a TTY (`index.ts:730`).
- **Example project name** changed from `flanker-study` to `my-experiment`, and marked explicitly as an example.

No new recipes/troubleshooting/`--help` content, and no CLI runtime changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)