### PR TITLE
fix(metadata,cli): strip leading UTF-8 BOM from CSV input

### DIFF
--- a/.changeset/csv-strip-bom.md
+++ b/.changeset/csv-strip-bom.md
@@ -3,13 +3,16 @@
 "@jspsych/metadata-cli": patch
 ---
 
-fix(metadata,cli): strip a leading UTF-8 BOM from CSV input
+fix(metadata,cli): strip a leading UTF-8 BOM from CSV and JSON input
 
 CSVs exported by Excel (and similar tools) begin with a UTF-8 BOM (U+FEFF).
 The shared `parseCSV` previously folded that BOM into the first header,
 producing a corrupted variable name like `﻿Participant_ID` that is not valid
-Psych-DS. `parseCSV` now passes `bom: true` to `csv-parse` so the first
-variable is named exactly as written (e.g. `Participant_ID`).
+Psych-DS. `parseCSV` now passes `bom: true` to `csv-parse`, and `parseJsonData`
+strips the same BOM before parsing, so the first variable is named exactly as
+written (e.g. `Participant_ID`) and BOM-prefixed JSON/JSON-Lines no longer fail
+to parse (which previously, for inputs with nested-array columns, could abort an
+interactive run with a rename-plan mismatch).
 
 The CLI also strips a leading BOM from the file content before writing the
 data file into the Psych-DS `data/` directory. A clean CSV is written

--- a/.changeset/csv-strip-bom.md
+++ b/.changeset/csv-strip-bom.md
@@ -1,0 +1,20 @@
+---
+"@jspsych/metadata": patch
+"@jspsych/metadata-cli": patch
+---
+
+fix(metadata,cli): strip a leading UTF-8 BOM from CSV input
+
+CSVs exported by Excel (and similar tools) begin with a UTF-8 BOM (U+FEFF).
+The shared `parseCSV` previously folded that BOM into the first header,
+producing a corrupted variable name like `﻿Participant_ID` that is not valid
+Psych-DS. `parseCSV` now passes `bom: true` to `csv-parse` so the first
+variable is named exactly as written (e.g. `Participant_ID`).
+
+The CLI also strips a leading BOM from the file content before writing the
+data file into the Psych-DS `data/` directory. A clean CSV is written
+verbatim, so without this the persisted file would keep a BOM-prefixed first
+column that no longer matches the BOM-stripped variable name in the metadata,
+failing validation with `CSV_COLUMN_MISSING_FROM_METADATA` and
+`VARIABLE_MISSING_FROM_CSV_COLUMNS`. Surfaced by the OSF lip-kinematics
+validation dataset (osf.io/9v4t6).

--- a/packages/cli/src/data.ts
+++ b/packages/cli/src/data.ts
@@ -339,7 +339,12 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
   if (verbose) console.log("Reading file:", filePath);
 
   try {
-    const content = await fs.promises.readFile(filePath, "utf8");
+    let content = await fs.promises.readFile(filePath, "utf8");
+    // Strip a leading UTF-8 BOM (e.g. from Excel exports) so it is not written back into the
+    // Psych-DS data file. parseCSV strips it for parsing, but a clean CSV is written verbatim
+    // below; without this the persisted file keeps a BOM-prefixed first column that no longer
+    // matches the BOM-stripped variable name in the metadata, and validation fails.
+    if (content.charCodeAt(0) === 0xfeff) content = content.slice(1);
     const fileExtension = path.extname(file).toLowerCase();
 
     // Rows parsed from this file, reused by the conversion path below so the file is parsed

--- a/packages/cli/tests/data.test.ts
+++ b/packages/cli/tests/data.test.ts
@@ -342,6 +342,34 @@ describe("processDirectory output-directory creation (#118)", () => {
     expect(failed).toBe(0);
     expect(fs.existsSync(path.join(dataDir, "subject-1_data.csv"))).toBe(true);
   });
+
+  test("strips a leading UTF-8 BOM so the written data file and metadata agree on the first column", async () => {
+    // Excel-exported CSVs (like the OSF lip-kinematics dataset, osf.io/9v4t6) start with a UTF-8
+    // BOM. The persisted data file must not carry it forward, otherwise the validator sees a
+    // BOM-prefixed first column that no longer matches the BOM-stripped variable name in the
+    // metadata (CSV_COLUMN_MISSING_FROM_METADATA + VARIABLE_MISSING_FROM_CSV_COLUMNS).
+    const srcDir = path.join(tmpDir, "src");
+    const dataDir = path.join(tmpDir, "project", "data");
+    fs.mkdirSync(srcDir);
+    fs.writeFileSync(
+      path.join(srcDir, "subject-1.csv"),
+      "﻿Participant_ID,trial_type,rt\np01,jsPsych-html-keyboard-response,450",
+    );
+
+    const metadata = new JsPsychMetadata();
+    const { failed } = await processDirectory(metadata, srcDir, false, dataDir);
+    expect(failed).toBe(0);
+
+    // The written data file's first column has no BOM.
+    const written = fs.readFileSync(path.join(dataDir, "subject-1_data.csv"), "utf8");
+    expect(written.charCodeAt(0)).not.toBe(0xfeff);
+    expect(written.startsWith("Participant_ID,")).toBe(true);
+
+    // The metadata variable name matches it exactly.
+    const names = (metadata.getMetadata().variableMeasured as any[]).map((v) => v.name);
+    expect(names).toContain("Participant_ID");
+    expect(names).not.toContain("﻿Participant_ID");
+  });
 });
 
 describe("processDirectory JSON → CSV conversion", () => {

--- a/packages/cli/tests/data.test.ts
+++ b/packages/cli/tests/data.test.ts
@@ -559,6 +559,36 @@ describe("processDirectory JSON → CSV conversion", () => {
     expect(written).toEqual(["subject-7_data.csv", "subject-7_measure-mouseTracking_data.csv"]);
   });
 
+  // Regression: the BOM strip must reach the pre-pass (analyzeOutputColumns), not just processFile.
+  // A BOM-prefixed JSON/JSONL with a nested-array column used to throw in the pre-pass (parseJsonData
+  // choked on the BOM), so the rename plan reserved NO sidecar name; processFile then stripped the
+  // BOM, succeeded, and extracted the array — a sidecar the plan never approved, aborting the whole
+  // run with RenamePlanError. parseJsonData now strips the BOM, so the plan and the write agree.
+  test("a BOM-prefixed JSON with a nested array does not abort the rename-plan run", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    const dataDir = path.join(tmpDir, "data");
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(dataDir);
+    const rows = [
+      { trial_index: 0, mouse_tracking: [{ x: 1, y: 2 }] },
+      { trial_index: 1, mouse_tracking: [{ x: 3, y: 4 }] },
+    ];
+    fs.writeFileSync(path.join(srcDir, "raw-export.json"), "﻿" + JSON.stringify(rows));
+
+    const key = path.resolve(srcDir, "raw-export.json");
+    const columns = await analyzeOutputColumns(srcDir);
+    // The pre-pass must see the sidecar column despite the BOM, so the plan reserves a name for it.
+    expect(columns[0].arrayColumns).toEqual(["mouse_tracking"]);
+    const normalizedBases = new Map([[key, "subject-7"]]);
+    const renamePlan = planRenames(columns.map((c) => ({ key: c.key, base: "subject-7", arrayColumns: c.arrayColumns, objectColumns: c.objectColumns })));
+
+    const { failed } = await processDirectory(new JsPsychMetadata(), srcDir, false, dataDir, { normalizedBases, renamePlan });
+
+    expect(failed).toBe(0);
+    const written = fs.readdirSync(dataDir).filter((f) => f.endsWith(".csv")).sort();
+    expect(written).toEqual(["subject-7_data.csv", "subject-7_measure-mouseTracking_data.csv"]);
+  });
+
   test("aborts with RenamePlanError when the data produces a column the plan didn't approve", async () => {
     const srcDir = path.join(tmpDir, "src");
     const dataDir = path.join(tmpDir, "data");

--- a/packages/metadata/src/utils.ts
+++ b/packages/metadata/src/utils.ts
@@ -132,6 +132,12 @@ export function parseJsonData(
   options: { tagSourceRecordId?: boolean } = {},
   stats?: { synthesizedSourceRecordId?: boolean }
 ): any {
+  // Strip a leading UTF-8 BOM (e.g. from Excel/PowerShell exports) so neither JSON.parse nor the
+  // JSON-Lines fallback chokes on it. Mirrors parseCSV's `bom: true`, keeping every read site
+  // (processFile, analyzeOutputColumns, preAnalyzeDirectory) consistent rather than relying on
+  // each caller to strip it first.
+  if (content.charCodeAt(0) === 0xfeff) content = content.slice(1);
+
   // Fast path: a single, well-formed JSON document. Covers the standard single array
   // (including pretty-printed/multi-line) with no behaviour change for existing callers.
   // unwrapTrials accepts an exact { "trials": [...] } wrapper (e.g. OSF exports) and returns

--- a/packages/metadata/src/utils.ts
+++ b/packages/metadata/src/utils.ts
@@ -565,7 +565,8 @@ export async function parseCSV(input) {
   return new Promise((resolve, reject) => {
     parse(input, {
       columns: true, // Treat the first row as headers
-      delimiter: ',' // Specify the delimiter (e.g., comma)
+      delimiter: ',', // Specify the delimiter (e.g., comma)
+      bom: true // Strip a leading UTF-8 BOM so the first header name isn't corrupted (e.g. "﻿Participant_ID")
     }, (err, records) => {
       if (err) {
         reject(err);

--- a/packages/metadata/tests/csv-input.stress.test.ts
+++ b/packages/metadata/tests/csv-input.stress.test.ts
@@ -181,3 +181,30 @@ describe("CSV / JSON parity for unambiguously-typed columns (stress)", () => {
     jest.restoreAllMocks();
   });
 });
+
+describe("CSV leading UTF-8 BOM handling (regression)", () => {
+  // Excel and similar tools prepend a UTF-8 BOM (U+FEFF) to CSV exports. Without bom:true in the
+  // csv-parse options, that BOM is folded into the first header, producing a corrupted variable
+  // name like "﻿Participant_ID" that is not valid Psych-DS. Mirrors the first column of the
+  // OSF lip-kinematics validation dataset (osf.io/9v4t6) that surfaced this.
+  const BOM = "﻿";
+  const csv =
+    `${BOM}Participant_ID,trial_type,trial_index,num\n` +
+    "p01,t,0,5\n" +
+    "p02,t,1,9\n";
+
+  test("strips the BOM so the first variable is named exactly Participant_ID", async () => {
+    (global as any).fetch = mockFetch;
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const metadata = new JsPsychMetadata();
+    await metadata.generate(csv, {}, "csv");
+    const names = metadata.getMetadata().variableMeasured.map((v: any) => v.name);
+
+    expect(names[0]).toBe("Participant_ID");
+    expect(names[0].charCodeAt(0)).not.toBe(0xfeff);
+    expect(names).not.toContain(`${BOM}Participant_ID`);
+
+    jest.restoreAllMocks();
+  });
+});

--- a/packages/metadata/tests/csv-input.stress.test.ts
+++ b/packages/metadata/tests/csv-input.stress.test.ts
@@ -207,4 +207,24 @@ describe("CSV leading UTF-8 BOM handling (regression)", () => {
 
     jest.restoreAllMocks();
   });
+
+  test("JSON-Lines: strips the BOM so the first line parses and the variable is named Participant_ID", async () => {
+    // A BOM on the first JSONL line previously made JSON.parse throw, skipping the whole file.
+    // parseJsonData now strips it, mirroring parseCSV's bom:true.
+    (global as any).fetch = mockFetch;
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const jsonl =
+      `${BOM}{"Participant_ID":"p01","trial_type":"t","trial_index":0}\n` +
+      `{"Participant_ID":"p02","trial_type":"t","trial_index":1}\n`;
+
+    const metadata = new JsPsychMetadata();
+    await metadata.generate(jsonl, {}, "json");
+    const names = metadata.getMetadata().variableMeasured.map((v: any) => v.name);
+
+    expect(names).toContain("Participant_ID");
+    expect(names).not.toContain(`${BOM}Participant_ID`);
+
+    jest.restoreAllMocks();
+  });
 });


### PR DESCRIPTION
## What

CSVs exported by Excel and similar tools begin with a UTF-8 BOM (U+FEFF). The shared `parseCSV` folded that BOM into the first header, producing a corrupted variable name like `﻿Participant_ID` that is not valid Psych-DS.

This was surfaced by testing the OSF lip-kinematics validation dataset ([osf.io/9v4t6](https://osf.io/9v4t6/overview)) — `ValidationExperiment2.csv` starts with a BOM.

## Changes

- **`packages/metadata/src/utils.ts`** — pass `bom: true` to `csv-parse` in `parseCSV`, so the first variable is named exactly as written (e.g. `Participant_ID`).
- **`packages/cli/src/data.ts`** — strip a leading BOM from file content before writing the data file into the Psych-DS `data/` directory. A clean CSV is written verbatim, so without this the persisted file would keep a BOM-prefixed first column that no longer matches the BOM-stripped variable name in the metadata, failing validation with `CSV_COLUMN_MISSING_FROM_METADATA` + `VARIABLE_MISSING_FROM_CSV_COLUMNS`.

The frontend was already immune (it reads via `FileReader.readAsText`, whose UTF-8 decode strips the BOM); this brings the library and CLI in line with that behavior.

## Tests

- `packages/metadata/tests/csv-input.stress.test.ts` — BOM-prefixed CSV; asserts the first variable is exactly `Participant_ID` with no leading `﻿`.
- `packages/cli/tests/data.test.ts` — BOM-prefixed CSV through `processDirectory`; asserts the written data file has no BOM and matches the metadata name.

## Verification

- metadata suite: 249/249 ✓ · CLI suite: 159/159 ✓ · both builds ✓
- End-to-end on the real OSF `ValidationExperiment2.csv` via the CLI: **Psych-DS validation passed (0 errors, 10 standard warnings)**; written header is `Participant_ID` (no BOM bytes); no BOM-corrupted variable names.

No behavior change for BOM-free files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)