### PR TITLE
feat(cli,frontend): preserve original under data/raw/ whenever output is transformed

### DIFF
--- a/.changeset/preserve-raw-on-transform.md
+++ b/.changeset/preserve-raw-on-transform.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/metadata-cli": patch
+---
+
+The CLI and web wizard now preserve the untouched original under `data/raw/` whenever the Psych-DS output is not a verbatim, same-named copy of the input — not just for JSON. This now also covers CSV inputs that were **renamed** to a Psych-DS-compliant name (e.g. `mydata.csv` → `subject-x_data.csv`) and CSV inputs that had to be **re-serialised** (malformed quotes repaired). A clean CSV written byte-for-byte under its own compliant name is the only case with no separate raw form, so nothing is duplicated. The existing flat-directory disambiguation and root `.psychds-ignore` (so the validator skips `data/raw/`) apply to these preserved CSVs too.

--- a/packages/cli/src/data.ts
+++ b/packages/cli/src/data.ts
@@ -425,27 +425,16 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
         return name;
       };
 
-      // Preserve the original JSON under data/raw/ (CSV inputs are already tabular, so they
-      // have no separate "raw" form). data/raw/ is flat (one level deep is flattened), so
-      // same-named originals from different source subdirectories must be disambiguated or
-      // they would overwrite one another.
-      if (isJsonDataExt(fileExtension)) {
-        const rawDir = path.join(targetDirectoryPath, 'raw');
-        await fs.promises.mkdir(rawDir, { recursive: true });
-        const rawName = disambiguateFilename(file, usedRawFilenames);
-        usedRawFilenames.add(rawName);
-        if (rawName !== file) {
-          console.log(`  ! raw/"${file}" already exists; saving original as raw/"${rawName}" instead.`);
-        }
-        await fs.promises.writeFile(path.join(rawDir, rawName), content);
-      }
-
       // Sidecar CSVs: one per array-of-objects column and one per plain-object column
       // detected during generate(). Arrays get element_index in their priority columns;
       // objects get one row per trial (join keys only).
       const extractedArrays = metadata.getExtractedArrays();
       const extractedObjects = metadata.getExtractedObjects();
       const joinKeys = metadata.getArrayJoinKeys();
+
+      // The Psych-DS name written for this file's main table, captured by whichever write path
+      // runs below so the raw-preservation check can compare it against the input filename.
+      let mainOutputName: string | undefined;
 
       if (planned) {
         const priorityCols = [...joinKeys, 'element_index'];
@@ -482,6 +471,7 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
         };
 
         const mainName = reserve(planned.mainName, 'main output');
+        mainOutputName = mainName;
         // A clean CSV keeps its exact bytes; JSON or a dirty CSV (whose unnamed row-index columns
         // generate() already stripped from mainRows) is serialised from those cleaned rows.
         await fs.promises.writeFile(
@@ -520,6 +510,28 @@ const processFile = async (metadata: JsPsychMetadata, directoryPath: string, fil
             console.log(`  → wrote ${what}`);
           }
         }
+        mainOutputName = built.find((f) => f.kind === 'main')?.filename;
+      }
+
+      // Preserve the untouched original under data/raw/ whenever the Psych-DS output is not a
+      // verbatim, same-named copy of the input. That covers: JSON/JSONL (always converted to
+      // CSV); a CSV that had to be re-serialised (csvVerbatimEligible === false, e.g. malformed
+      // quotes generate() repaired); and a CSV whose filename was changed to a compliant name
+      // (mainOutputName !== file). A clean CSV written verbatim under its own name is the only
+      // case with no separate raw form. data/raw/ is flat (one level deep is flattened), so
+      // same-named originals from different source subdirectories are disambiguated or they
+      // would overwrite one another.
+      const transformed =
+        isJsonDataExt(fileExtension) || !csvVerbatimEligible || mainOutputName !== file;
+      if (transformed) {
+        const rawDir = path.join(targetDirectoryPath, 'raw');
+        await fs.promises.mkdir(rawDir, { recursive: true });
+        const rawName = disambiguateFilename(file, usedRawFilenames);
+        usedRawFilenames.add(rawName);
+        if (rawName !== file) {
+          console.log(`  ! raw/"${file}" already exists; saving original as raw/"${rawName}" instead.`);
+        }
+        await fs.promises.writeFile(path.join(rawDir, rawName), content);
       }
     }
   } catch (err) {

--- a/packages/cli/tests/data.test.ts
+++ b/packages/cli/tests/data.test.ts
@@ -330,8 +330,8 @@ describe("processDirectory output-directory creation (#118)", () => {
     // Mirrors an existing Psych-DS project with no data/ dir: the output path doesn't exist yet.
     const dataDir = path.join(tmpDir, "project", "data");
     fs.mkdirSync(srcDir);
-    // A CSV input (no data/raw/ is created for CSV, so nothing else would make data/ first).
-    // "subject-1" yields the compliant "subject-1_data.csv" without needing a rename plan.
+    // A CSV input renamed to the compliant "subject-1_data.csv" without needing a rename plan.
+    // (The rename means its original is now also preserved under data/raw/.)
     fs.writeFileSync(path.join(srcDir, "subject-1.csv"), "trial_type,rt\njsPsych-html-keyboard-response,450");
 
     expect(fs.existsSync(dataDir)).toBe(false);
@@ -369,6 +369,66 @@ describe("processDirectory output-directory creation (#118)", () => {
     const names = (metadata.getMetadata().variableMeasured as any[]).map((v) => v.name);
     expect(names).toContain("Participant_ID");
     expect(names).not.toContain("﻿Participant_ID");
+  });
+});
+
+describe("processDirectory CSV raw-original preservation", () => {
+  test("preserves the original under data/raw/ when a clean CSV is renamed to a compliant name", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    const dataDir = path.join(tmpDir, "data");
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(dataDir);
+    // Non-compliant name → renamed to "subject-7_data.csv"; content itself is clean (written verbatim).
+    const original = "trial_type,rt\njsPsych-html-keyboard-response,450";
+    fs.writeFileSync(path.join(srcDir, "trial.csv"), original);
+
+    const normalizedBases = new Map([[path.resolve(srcDir, "trial.csv"), "subject-7"]]);
+    const { failed } = await processDirectory(new JsPsychMetadata(), srcDir, false, dataDir, { normalizedBases });
+    expect(failed).toBe(0);
+
+    // Converted file is written under the new name; the original is kept under its old name in data/raw/.
+    expect(fs.existsSync(path.join(dataDir, "subject-7_data.csv"))).toBe(true);
+    const rawPath = path.join(dataDir, "raw", "trial.csv");
+    expect(fs.existsSync(rawPath)).toBe(true);
+    expect(fs.readFileSync(rawPath, "utf8")).toBe(original);
+    // A .psychds-ignore is dropped at the dataset root so the validator skips data/raw/.
+    expect(fs.existsSync(path.join(tmpDir, ".psychds-ignore"))).toBe(true);
+  });
+
+  test("does NOT create a raw original for an already-compliant, verbatim-copied CSV", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    const dataDir = path.join(tmpDir, "data");
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(dataDir);
+    // Already compliant AND clean → written byte-for-byte under its own name, so there is no
+    // separate "raw" form to preserve.
+    fs.writeFileSync(path.join(srcDir, "subject-1_data.csv"), "trial_type,rt\njsPsych-html-keyboard-response,450");
+
+    const { failed } = await processDirectory(new JsPsychMetadata(), srcDir, false, dataDir);
+    expect(failed).toBe(0);
+
+    expect(fs.existsSync(path.join(dataDir, "subject-1_data.csv"))).toBe(true);
+    expect(fs.existsSync(path.join(dataDir, "raw"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".psychds-ignore"))).toBe(false);
+  });
+
+  test("preserves the original when a CSV must be re-serialised even though its name is unchanged", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    const dataDir = path.join(tmpDir, "data");
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(dataDir);
+    // Compliant name, but the stimulus HTML has unescaped quotes — only parses via quote relaxation,
+    // so it is re-serialised (not byte-for-byte) and the malformed original is preserved under data/raw/.
+    const original = 'trial_type,stimulus\nhtml-keyboard-response,<div class = "Box">hi</div>';
+    fs.writeFileSync(path.join(srcDir, "subject-1_data.csv"), original);
+
+    const { failed } = await processDirectory(new JsPsychMetadata(), srcDir, false, dataDir);
+    expect(failed).toBe(0);
+
+    expect(fs.existsSync(path.join(dataDir, "subject-1_data.csv"))).toBe(true);
+    const rawPath = path.join(dataDir, "raw", "subject-1_data.csv");
+    expect(fs.existsSync(rawPath)).toBe(true);
+    expect(fs.readFileSync(rawPath, "utf8")).toBe(original);
   });
 });
 

--- a/packages/frontend/src/pages/DataUpload.tsx
+++ b/packages/frontend/src/pages/DataUpload.tsx
@@ -296,6 +296,10 @@ const DataUpload: React.FC<DataUploadProps> = ({
         // isn't a jsPsych trial table) before generate() runs — matching the CLI.
         let mainRows: Array<Record<string, any>> = [];
         let mainContent: string | undefined;
+        // A clean CSV written verbatim under its own compliant name is the only input with no
+        // separate "raw" form; everything else (JSON, a re-serialised CSV, or a renamed CSV) is
+        // transformed and its original is preserved under data/raw/ below. Stays false for JSON.
+        let csvVerbatimEligible = false;
         if (type === 'json') {
           // Tag a per-line source_record_id for JSON-Lines (a no-op for a single array) so the
           // main CSV carries the same join-key column generate() promotes for the sidecars.
@@ -320,7 +324,7 @@ const DataUpload: React.FC<DataUploadProps> = ({
           // strict CSV parse, so re-serialise it instead.
           const parsed = await parseCSVForWrite(content);
           mainRows = parsed.rows;
-          const csvVerbatimEligible = parsed.verbatimSafe && !hasUnnamedColumns(mainRows);
+          csvVerbatimEligible = parsed.verbatimSafe && !hasUnnamedColumns(mainRows);
           await jsPsychMetadata.generate(mainRows, {}, 'csv', {
             arrayJoinKeys: joinKeys,
             suppressJoinKeyWarning: suppressWarning,
@@ -340,8 +344,14 @@ const DataUpload: React.FC<DataUploadProps> = ({
         });
         for (const f of built) await store.write(`data/${f.filename}`, f.content);
 
-        // Preserve the original JSON under data/raw/ (CSV inputs are already tabular).
-        if (type === 'json') {
+        // Preserve the untouched original under data/raw/ whenever the Psych-DS output is not a
+        // verbatim, same-named copy of the input: JSON is always converted to CSV; a CSV is
+        // transformed when it had to be re-serialised (csvVerbatimEligible === false) or when its
+        // filename changed to a compliant name (mainName !== file.name). data/raw/ is flat, so
+        // same-named originals from different source folders are disambiguated.
+        const mainName = built.find(f => f.kind === 'main')?.filename;
+        const transformed = type === 'json' || !csvVerbatimEligible || mainName !== file.name;
+        if (transformed) {
           const rawName = disambiguateFlatFilename(file.name, usedRawFilenames);
           usedRawFilenames.add(rawName);
           await store.write(`data/raw/${rawName}`, content);

--- a/packages/frontend/tests/DataUpload.test.tsx
+++ b/packages/frontend/tests/DataUpload.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import JSZip from "jszip";
-import { analyzeJoinKeys } from "@jspsych/metadata";
+import { analyzeJoinKeys, buildPsychDSDataFiles, isValidPsychDSDataFilename, parseCSVForWrite } from "@jspsych/metadata";
 import DataUpload, { emptyDataSession } from "../src/pages/DataUpload";
 import type { DataSession } from "../src/pages/DataUpload";
 
@@ -29,6 +29,9 @@ jest.mock("jszip", () => ({
 }));
 
 const mockAnalyzeJoinKeys = analyzeJoinKeys as jest.Mock;
+const mockBuild = buildPsychDSDataFiles as jest.Mock;
+const mockIsValid = isValidPsychDSDataFilename as jest.Mock;
+const mockParseCSVForWrite = parseCSVForWrite as jest.Mock;
 const mockLoadAsync = (JSZip as { loadAsync: jest.Mock }).loadAsync;
 
 function makeFile(name: string, content = "col,val\n1,2", relativePath = "") {
@@ -325,6 +328,57 @@ describe("DataUpload", () => {
       const continueBtn = await screen.findByRole("button", { name: "Continue →" });
       await userEvent.click(continueBtn);
       expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    // ── raw-original preservation ──────────────────────────────────────────
+    // The original is kept under data/raw/ whenever the Psych-DS output is not a verbatim,
+    // same-named copy of the input. The store flows back through onSessionChange.
+    async function processedStore() {
+      let store: any;
+      await waitFor(() => {
+        const calls = onSessionChange.mock.calls;
+        store = calls[calls.length - 1]?.[0]?.convertedStore;
+        expect(store).not.toBeNull();
+      });
+      return store;
+    }
+
+    test("preserves a renamed CSV's original under data/raw/ with its old name", async () => {
+      // Clean CSV (verbatimSafe from the default mock) renamed sub01.csv → subject-sub01_data.csv.
+      mockBuild.mockReturnValueOnce([{ filename: "subject-sub01_data.csv", content: "rt\n100", kind: "main" }]);
+      const { container } = render(<DataUpload {...props()} />);
+      await pickAndProcess(makeFile("sub01.csv", "rt\n100"), container);
+      await screen.findByRole("button", { name: "Continue →" });
+
+      const store = await processedStore();
+      expect(store.paths()).toContain("data/raw/sub01.csv");
+      expect(store.paths()).toContain(".psychds-ignore");
+    });
+
+    test("does NOT preserve raw for an already-compliant, verbatim-copied CSV", async () => {
+      // compliantBase keeps the name; the builder writes it unchanged and verbatim → no raw form.
+      mockIsValid.mockReturnValue(true);
+      mockBuild.mockReturnValueOnce([{ filename: "subject-sub01_data.csv", content: "rt\n100", kind: "main" }]);
+      const { container } = render(<DataUpload {...props()} />);
+      await pickAndProcess(makeFile("subject-sub01_data.csv", "rt\n100"), container);
+      await screen.findByRole("button", { name: "Continue →" });
+
+      const store = await processedStore();
+      expect(store.paths().some((p: string) => p.startsWith("data/raw/"))).toBe(false);
+      expect(store.paths()).not.toContain(".psychds-ignore");
+    });
+
+    test("preserves raw when a CSV must be re-serialised even though its name is unchanged", async () => {
+      // verbatimSafe:false → the malformed original is re-serialised, so it's preserved under data/raw/.
+      mockParseCSVForWrite.mockResolvedValueOnce({ rows: [], verbatimSafe: false });
+      mockIsValid.mockReturnValue(true);
+      mockBuild.mockReturnValueOnce([{ filename: "subject-sub01_data.csv", content: "rt\n100", kind: "main" }]);
+      const { container } = render(<DataUpload {...props()} />);
+      await pickAndProcess(makeFile("subject-sub01_data.csv", 'stimulus\n<div class="x">'), container);
+      await screen.findByRole("button", { name: "Continue →" });
+
+      const store = await processedStore();
+      expect(store.paths()).toContain("data/raw/subject-sub01_data.csv");
     });
   });
 


### PR DESCRIPTION
## Summary

Broadens raw-original preservation beyond JSON. Previously both the CLI (`processFile`) and the web wizard (`runGenerate`) kept the untouched input under `data/raw/` **only for JSON/JSONL** (CSV was assumed to have no separate raw form). This changes the trigger to *"the input was transformed"* — i.e. preserve the original whenever the Psych-DS output is **not a verbatim, same-named copy** of the input:

```
transformed = isJsonDataExt(ext) || !csvVerbatimEligible || mainName !== inputName
```

Newly covered for CSV inputs:
- **Renamed** — a clean CSV whose content is unchanged but whose filename was changed to a Psych-DS-compliant name (e.g. `mydata.csv` → `subject-x_data.csv`). The original is kept under its old name. *(Near-universal for real OSF data — the high-impact case.)*
- **Re-serialised** — a CSV that only parsed thanks to quote relaxation (`#132`) and is therefore rewritten, so the bytes change. The malformed original is preserved.

A clean CSV written byte-for-byte under its own already-compliant name is the **only** no-raw case, so nothing is duplicated. The existing flat-dir disambiguation and root `.psychds-ignore` (so the validator skips `data/raw/`) apply to these preserved CSVs too.

> [!NOTE]
> Stacked on #132 (`fix/csv-relax-quotes`) — base this PR against that branch. This intentionally changes the **output layout of currently-working datasets** (renamed CSVs now grow a `data/raw/` dir + `.psychds-ignore`), which is why it's a separate PR from the tight #132 bug fix.

## Implementation
- **CLI** (`packages/cli/src/data.ts`): capture `mainOutputName` from whichever write path ran (planned → `planned.mainName`; non-planned → the built `main` file), move the raw-write block to after the output is written, and replace the `isJsonDataExt` gate with the `transformed` check.
- **Frontend** (`packages/frontend/src/pages/DataUpload.tsx`): hoist `csvVerbatimEligible` out of the CSV branch and compare the built main filename against `file.name`.

BOM-only changes are deliberately **not** treated as transformed — the preserved `content` is already BOM-stripped, so preserving it would be pointless.

## Testing
- 3 CLI tests (`data.test.ts`): renamed CSV preserved; already-compliant verbatim CSV gets **no** `data/raw/`; re-serialised CSV preserved even with an unchanged name.
- 3 frontend component tests (`DataUpload.test.tsx`): drive the real component and inspect `convertedStore.paths()`.
- Full suite: **664 passing**.
- Manually verified end-to-end on the real OSF **phxq4** dataset (the unquoted-stimulus-HTML files that previously failed to parse): all files read, re-serialised output in `data/`, malformed originals preserved in `data/raw/`, `.psychds-ignore` written. Also confirmed clean DataPipe CSVs: renamed → preserved; already-compliant → not preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)